### PR TITLE
Implement FP-101 planning baseline assumptions

### DIFF
--- a/src/calc/aca.ts
+++ b/src/calc/aca.ts
@@ -1,4 +1,5 @@
-import { FPL_2025, ACA_CONTRIBUTION_TABLE, ACA_AGE_FACTORS, SILVER_BASE_21, GOLD_BASE_21 } from '../constants/aca';
+import { ACA_AGE_FACTORS, ACA_CONTRIBUTION_TABLE, ACA_FPL_BASELINE, GOLD_BASE_21, SILVER_BASE_21 } from '../constants/aca';
+import { PLANNING_GROWTH_RATES, scalePlanningAmount } from '../constants/planning';
 import { fmt } from '../utils/format';
 
 /**
@@ -6,7 +7,7 @@ import { fmt } from '../utils/format';
  * Returns null if not eligible (below 100% FPL or above 400% FPL).
  */
 export function getAcaContributionPct(income: number): number | null {
-  return getAcaContributionPctForFpl(income, FPL_2025);
+  return getAcaContributionPctForFpl(income, ACA_FPL_BASELINE);
 }
 
 export function getAcaContributionPctForFpl(income: number, fpl: number): number | null {
@@ -54,8 +55,11 @@ export interface AcaSubsidyResult {
   fplRatio: number;
 }
 
-export function getAcaFpl(yearsFromBase = 0, inflationRate = 0): number {
-  return FPL_2025 * Math.pow(1 + inflationRate, Math.max(yearsFromBase, 0));
+export function getAcaFpl(
+  yearsFromBase = 0,
+  inflationRate = PLANNING_GROWTH_RATES.acaThresholds,
+): number {
+  return scalePlanningAmount(ACA_FPL_BASELINE, yearsFromBase, inflationRate);
 }
 
 export function calcAcaSubsidyForFpl(magi: number, age: number, fpl: number): AcaSubsidyResult {
@@ -121,7 +125,7 @@ export function calcAcaSubsidyForYear(magi: number, age: number, yearsFromBase =
  * Calculate ACA subsidy for a given MAGI and age.
  */
 export function calcAcaSubsidy(magi: number, age: number): AcaSubsidyResult {
-  return calcAcaSubsidyForFpl(magi, age, FPL_2025);
+  return calcAcaSubsidyForFpl(magi, age, ACA_FPL_BASELINE);
 }
 
 /**

--- a/src/calc/fire.ts
+++ b/src/calc/fire.ts
@@ -1,6 +1,7 @@
 import { calcAcaSubsidyForYear, estimateGoldPremium } from './aca';
 import { calcPayrollTax, calcProgressiveTax } from './tax';
 import { getMedicareAnnualCost } from './medicare';
+import { PLANNING_GROWTH_RATES } from '../constants/planning';
 
 export interface FirePlannerInputs {
   currentAge: number;
@@ -62,7 +63,7 @@ function clamp(value: number, min: number, max: number): number {
 }
 
 const MAX_PROJECTION_AGE = 100;
-const HEALTHCARE_INFLATION = 0.03;
+const HEALTHCARE_INFLATION = PLANNING_GROWTH_RATES.healthcareCosts;
 
 export function calculateFirePlan(inputs: FirePlannerInputs): FirePlannerResult {
   const currentAge = clamp(inputs.currentAge || 0, 18, 100);

--- a/src/calc/medicare.ts
+++ b/src/calc/medicare.ts
@@ -1,4 +1,5 @@
 import { MEDICARE_BASE, MEDICARE_OOP_BY_AGE, IRMAA_BRACKETS } from '../constants/medicare';
+import { PLANNING_GROWTH_RATES } from '../constants/planning';
 
 export interface IrmaaSurcharge {
   partB: number;
@@ -32,7 +33,12 @@ export function getIrmaaSurcharge(magi: number): IrmaaSurcharge {
  * and number of years since age 65.
  * Includes base premiums, out-of-pocket, and IRMAA surcharges, all adjusted for inflation.
  */
-export function getMedicareAnnualCost(age: number, magi: number, inflation: number, yearsFrom65: number): MedicareAnnualCost {
+export function getMedicareAnnualCost(
+  age: number,
+  magi: number,
+  inflation = PLANNING_GROWTH_RATES.healthcareCosts,
+  yearsFrom65: number,
+): MedicareAnnualCost {
   const inflationFactor = Math.pow(1 + inflation, yearsFrom65);
   const basePremiums = (MEDICARE_BASE.partB + MEDICARE_BASE.partD + MEDICARE_BASE.partBDeductible + MEDICARE_BASE.medigap) * inflationFactor;
   const oopAge = Math.min(Math.max(age, 65), 100);

--- a/src/calc/tax.ts
+++ b/src/calc/tax.ts
@@ -1,44 +1,45 @@
 import {
   ADDITIONAL_MEDICARE_RATE,
   ADDITIONAL_MEDICARE_THRESHOLD_SINGLE,
-  LTCG_BRACKETS_2026,
+  LTCG_TAX_BRACKETS_BASELINE,
   MEDICARE_PAYROLL_RATE,
+  ORDINARY_TAX_BRACKETS_BASELINE,
   SOCIAL_SECURITY_PAYROLL_RATE,
-  SOCIAL_SECURITY_WAGE_BASE_2026,
-  STANDARD_DEDUCTION,
-  TAX_BRACKETS_2026,
+  SOCIAL_SECURITY_WAGE_BASE_BASELINE,
+  STANDARD_DEDUCTION_BASELINE,
 } from '../constants/tax';
+import { PLANNING_GROWTH_RATES, scalePlanningAmount, scalePlanningBrackets } from '../constants/planning';
 import type { TaxBracket, TaxResult } from '../types';
 
 const SS_BASE_AMOUNT_SINGLE = 25000;
 const SS_ADJUSTED_BASE_SINGLE = 34000;
 
-function inflateAmount(amount: number, yearsFromStart = 0, inflationRate = 0): number {
-  return amount * Math.pow(1 + inflationRate, yearsFromStart);
+export function getInflationAdjustedStandardDeduction(
+  yearsFromStart = 0,
+  inflationRate = PLANNING_GROWTH_RATES.federalThresholds,
+): number {
+  return scalePlanningAmount(STANDARD_DEDUCTION_BASELINE, yearsFromStart, inflationRate);
 }
 
-function inflateBrackets(brackets: TaxBracket[], yearsFromStart = 0, inflationRate = 0): TaxBracket[] {
-  return brackets.map((bracket) => ({
-    min: inflateAmount(bracket.min, yearsFromStart, inflationRate),
-    max: Number.isFinite(bracket.max) ? inflateAmount(bracket.max, yearsFromStart, inflationRate) : Infinity,
-    rate: bracket.rate,
-  }));
+export function getInflationAdjustedSocialSecurityWageBase(
+  yearsFromStart = 0,
+  inflationRate = PLANNING_GROWTH_RATES.federalThresholds,
+): number {
+  return scalePlanningAmount(SOCIAL_SECURITY_WAGE_BASE_BASELINE, yearsFromStart, inflationRate);
 }
 
-export function getInflationAdjustedStandardDeduction(yearsFromStart = 0, inflationRate = 0): number {
-  return inflateAmount(STANDARD_DEDUCTION, yearsFromStart, inflationRate);
+export function getInflationAdjustedOrdinaryBrackets(
+  yearsFromStart = 0,
+  inflationRate = PLANNING_GROWTH_RATES.federalThresholds,
+): TaxBracket[] {
+  return scalePlanningBrackets(ORDINARY_TAX_BRACKETS_BASELINE, yearsFromStart, inflationRate);
 }
 
-export function getInflationAdjustedSocialSecurityWageBase(yearsFromStart = 0, inflationRate = 0): number {
-  return inflateAmount(SOCIAL_SECURITY_WAGE_BASE_2026, yearsFromStart, inflationRate);
-}
-
-export function getInflationAdjustedOrdinaryBrackets(yearsFromStart = 0, inflationRate = 0): TaxBracket[] {
-  return inflateBrackets(TAX_BRACKETS_2026, yearsFromStart, inflationRate);
-}
-
-export function getInflationAdjustedLtcgBrackets(yearsFromStart = 0, inflationRate = 0): TaxBracket[] {
-  return inflateBrackets(LTCG_BRACKETS_2026, yearsFromStart, inflationRate);
+export function getInflationAdjustedLtcgBrackets(
+  yearsFromStart = 0,
+  inflationRate = PLANNING_GROWTH_RATES.federalThresholds,
+): TaxBracket[] {
+  return scalePlanningBrackets(LTCG_TAX_BRACKETS_BASELINE, yearsFromStart, inflationRate);
 }
 
 export function getTopOfOrdinaryBracketGrossIncome(
@@ -100,7 +101,7 @@ export function calcPayrollTax(
 
 /**
  * Calculate progressive federal income tax for a given gross income (single filer).
- * Applies standard deduction automatically.
+ * Uses the 2026 planning baseline and applies the standard deduction automatically.
  */
 export function calcProgressiveTax(income: number, yearsFromStart = 0, inflationRate = 0): TaxResult {
   const deduction = getInflationAdjustedStandardDeduction(yearsFromStart, inflationRate);
@@ -120,7 +121,8 @@ export function calcProgressiveTax(income: number, yearsFromStart = 0, inflation
 
 /**
  * Calculate federal long-term capital gains tax for a single filer.
- * The standard deduction is applied against ordinary income first and then any remaining deduction shelters gains.
+ * Uses the 2026 planning baseline. The standard deduction is applied against
+ * ordinary income first and then any remaining deduction shelters gains.
  */
 export function calcLongTermCapitalGainsTax(
   ordinaryIncome: number,

--- a/src/constants/aca.ts
+++ b/src/constants/aca.ts
@@ -1,4 +1,6 @@
-export const FPL_2025 = 15650; // single person, 48 states
+import { PLANNING_BASE_YEAR } from './planning';
+
+export const ACA_FPL_BASELINE = 16050; // 2026 planning baseline, single person, 48 states
 
 // Applicable percentage table: [FPL%, contribution% of income]
 export const ACA_CONTRIBUTION_TABLE = [
@@ -33,3 +35,5 @@ export const SILVER_BASE_21 = 625 / 1.278;
 
 // Gold plan base premium at age 21 ($650/mo avg Gold at age 40)
 export const GOLD_BASE_21 = 650 / 1.278;
+
+export const ACA_PLANNING_BASELINE_LABEL = `${PLANNING_BASE_YEAR} planning baseline`;

--- a/src/constants/medicare.ts
+++ b/src/constants/medicare.ts
@@ -1,3 +1,5 @@
+import { PLANNING_BASE_YEAR } from './planning';
+
 export interface MedicareBase {
   partB: number;
   partD: number;
@@ -39,3 +41,5 @@ export const IRMAA_BRACKETS: IrmaaBracket[] = [
   { maxMagi: 500000, partBSurcharge: 5356,    partDSurcharge: 858 },
   { maxMagi: Infinity, partBSurcharge: 5965,  partDSurcharge: 943 },
 ];
+
+export const MEDICARE_PLANNING_BASELINE_LABEL = `${PLANNING_BASE_YEAR} planning baseline`;

--- a/src/constants/planning.ts
+++ b/src/constants/planning.ts
@@ -1,0 +1,27 @@
+import type { TaxBracket } from '../types';
+
+export const PLANNING_BASE_YEAR = 2026;
+
+export const PLANNING_GROWTH_RATES = {
+  federalThresholds: 0.025,
+  acaThresholds: 0.025,
+  healthcareCosts: 0.03,
+} as const;
+
+export function scalePlanningAmount(amount: number, yearsFromBase = 0, annualRate = 0): number {
+  return amount * Math.pow(1 + annualRate, Math.max(yearsFromBase, 0));
+}
+
+export function scalePlanningBrackets(
+  brackets: TaxBracket[],
+  yearsFromBase = 0,
+  annualRate = 0,
+): TaxBracket[] {
+  return brackets.map((bracket) => ({
+    min: scalePlanningAmount(bracket.min, yearsFromBase, annualRate),
+    max: Number.isFinite(bracket.max)
+      ? scalePlanningAmount(bracket.max, yearsFromBase, annualRate)
+      : Infinity,
+    rate: bracket.rate,
+  }));
+}

--- a/src/constants/tax.ts
+++ b/src/constants/tax.ts
@@ -1,7 +1,8 @@
 import type { TaxBracket, TaxLocationRule, AccountType, CategoryKey } from '../types';
+import { PLANNING_BASE_YEAR } from './planning';
 
-// 2026 OBBBA tax brackets (single filer)
-export const TAX_BRACKETS_2026: TaxBracket[] = [
+// 2026 planning baseline tax brackets (single filer)
+export const ORDINARY_TAX_BRACKETS_BASELINE: TaxBracket[] = [
   { min: 0, max: 12400, rate: 0.10 },
   { min: 12400, max: 50400, rate: 0.12 },
   { min: 50400, max: 105700, rate: 0.22 },
@@ -11,19 +12,21 @@ export const TAX_BRACKETS_2026: TaxBracket[] = [
   { min: 640600, max: Infinity, rate: 0.37 },
 ];
 
-export const STANDARD_DEDUCTION = 16100; // 2026 single
-export const SOCIAL_SECURITY_WAGE_BASE_2026 = 184500;
+export const STANDARD_DEDUCTION_BASELINE = 16100; // 2026 single
+export const SOCIAL_SECURITY_WAGE_BASE_BASELINE = 184500;
 export const SOCIAL_SECURITY_PAYROLL_RATE = 0.062;
 export const MEDICARE_PAYROLL_RATE = 0.0145;
 export const ADDITIONAL_MEDICARE_RATE = 0.009;
 export const ADDITIONAL_MEDICARE_THRESHOLD_SINGLE = 200000;
 
-// 2026 long-term capital gains brackets (single filer), taxable income basis
-export const LTCG_BRACKETS_2026: TaxBracket[] = [
+// 2026 planning baseline long-term capital gains brackets (single filer), taxable income basis
+export const LTCG_TAX_BRACKETS_BASELINE: TaxBracket[] = [
   { min: 0, max: 49450, rate: 0.00 },
   { min: 49450, max: 545500, rate: 0.15 },
   { min: 545500, max: Infinity, rate: 0.20 },
 ];
+
+export const TAX_PLANNING_BASELINE_LABEL = `${PLANNING_BASE_YEAR} planning baseline`;
 
 // RMD distribution periods by age (from IRS Uniform Lifetime Table)
 export const RMD_TABLE: Record<number, number> = {

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,6 +39,10 @@ import { renderSymbolCatalogPage } from './render/symbol-catalog';
 import { calcAcaSubsidy, calcAcaSubsidyForYear, estimateBenchmarkPremium, estimateGoldPremium, getAcaCliff } from './calc/aca';
 import { calcFederalIncomeTax, calcPayrollTax, calcProgressiveTax, calcTaxableSocialSecurity, getTopOfOrdinaryBracketGrossIncome } from './calc/tax';
 import { getIrmaaSurcharge, getMedicareAnnualCost } from './calc/medicare';
+import { ACA_FPL_BASELINE, ACA_PLANNING_BASELINE_LABEL } from './constants/aca';
+import { IRMAA_BRACKETS, MEDICARE_PLANNING_BASELINE_LABEL } from './constants/medicare';
+import { PLANNING_GROWTH_RATES } from './constants/planning';
+import { TAX_PLANNING_BASELINE_LABEL } from './constants/tax';
 import { simulateDrawdown, getRmdFactor } from './calc/drawdown';
 import { guessAccountType, guessCategory } from './calc/category';
 import { calculateFirePlan } from './calc/fire';
@@ -905,8 +909,8 @@ function updatePlannerTaxControls(): void {
   const autoRate = grossIncome > 0 ? ((incomeTax.tax + payrollTax.totalTax) / grossIncome) * 100 : 0;
   taxInput.disabled = autoInput.checked;
   hint.textContent = autoInput.checked
-    ? `Auto: ${autoRate.toFixed(1)}% effective tax from federal income tax plus employee Social Security and Medicare`
-    : `Override: use your own all-in effective tax rate instead of the automatic federal and payroll tax estimate`;
+    ? `Auto: ${autoRate.toFixed(1)}% effective tax from the ${TAX_PLANNING_BASELINE_LABEL} federal income tax plus employee Social Security and Medicare`
+    : `Override: use your own all-in effective tax rate instead of the automatic ${TAX_PLANNING_BASELINE_LABEL} federal and payroll estimate`;
 }
 
 function renderPlanner(forceChart = false, syncRetirementAge = true): void {
@@ -1280,7 +1284,7 @@ function renderHcAgeTable(): void {
   const earned = 0;
   const inv = getInvestmentIncome();
   const income = earned + inv.total;
-  const fplRatio = income / 15650;
+  const fplRatio = income / ACA_FPL_BASELINE;
   const cliffAmt = getAcaCliff();
 
   $('hcIncomeDisplay').textContent = `$${fmt(Math.round(income))}`;
@@ -1395,7 +1399,7 @@ function renderHcAgeTable(): void {
       </table>
     </div>
     <div style="margin-top:0.75rem;font-size:0.78rem;color:var(--muted);">
-      Gold plan premiums estimated using 2026 national averages ($650/mo at age 40) with the federal ACA age curve.
+      Gold plan premiums estimated using the ${ACA_PLANNING_BASELINE_LABEL} national averages ($650/mo at age 40) with the federal ACA age curve.
       Subsidies calculated against the Silver benchmark ($625/mo at age 40). Actual premiums vary by location.
       <span style="display:inline-flex;align-items:center;gap:0.3rem;margin-left:0.5rem;">
         <span class="dot" style="width:8px;height:8px;border-radius:2px;background:var(--muted);display:inline-block;"></span> Full premium
@@ -1406,10 +1410,12 @@ function renderHcAgeTable(): void {
 
 function renderHcIncomeTable(): void {
   const age = Math.min(readRetirementAge(), 64);
-  const incomes = [15000, 20000, 25000, 30000, 35000, 40000, 45000, 50000, 55000, 60000, 62000, 62600, 63000, 65000, 70000, 80000, 100000, 120000];
+  const cliffAmt = Math.round(getAcaCliff());
+  const incomes = [15000, 20000, 25000, 30000, 35000, 40000, 45000, 50000, 55000, 60000, cliffAmt - 1000, cliffAmt, cliffAmt + 500, 65000, 70000, 80000, 100000, 120000]
+    .filter((income, index, arr) => income > 0 && arr.indexOf(income) === index)
+    .sort((a, b) => a - b);
   const goldMonthly = estimateGoldPremium(age);
   const goldAnnual = goldMonthly * 12;
-  const cliffAmt = Math.round(getAcaCliff());
 
   $('hcIncomeTable').innerHTML = `
     <div style="overflow-x:auto;border:1px solid var(--border);border-radius:8px;">
@@ -1419,7 +1425,7 @@ function renderHcIncomeTable(): void {
         </tr></thead>
         <tbody>${incomes.map((inc, index) => {
           const aca = calcAcaSubsidy(inc, age);
-          const fplPct = fmtD((inc / 15650) * 100, 0);
+          const fplPct = fmtD((inc / ACA_FPL_BASELINE) * 100, 0);
           const prev = incomes[index - 1] || 0;
           const isCliff = inc > cliffAmt && prev <= cliffAmt;
           const atCliff = Math.abs(inc - cliffAmt) < 1000;
@@ -1443,8 +1449,8 @@ function renderHcIncomeTable(): void {
     </div>
     <div style="margin-top:0.75rem;font-size:0.78rem;color:var(--muted);">
       All values for a ${age}-year-old on a Gold plan ($${fmt(goldMonthly)}/mo full price).
-      <span style="color:var(--red);">Red line</span> marks the 400% FPL subsidy cliff at $${fmt(cliffAmt)}.
-      At $62,600 you get ~$${fmt(calcAcaSubsidy(62600, age).subsidy)}/yr in subsidies. At $63,000 you get nothing.
+      <span style="color:var(--red);">Red line</span> marks the 400% FPL subsidy cliff at $${fmt(cliffAmt)} on the ${ACA_PLANNING_BASELINE_LABEL}.
+      Near the cliff, a small MAGI increase can eliminate the modeled subsidy entirely.
     </div>`;
 }
 
@@ -1452,7 +1458,7 @@ function renderMedicareProjection(): void {
   const userAge = readRetirementAge();
   const lifeExp = readInt('coLifeExp', 90);
   const magi = getMagi() || 30000;
-  const inflation = 0.03;
+  const inflation = PLANNING_GROWTH_RATES.healthcareCosts;
 
   if (userAge > lifeExp) {
     $('medicareSummaryRow').innerHTML = '';
@@ -1500,7 +1506,7 @@ function renderMedicareProjection(): void {
     <div class="dd-summary-card">
       <div class="label">Avg Annual Cost</div>
       <div class="value">$${fmt(yearsOnMedicare > 0 ? Math.round(totalAll / yearsOnMedicare) : 0)}</div>
-      <div class="sub">Including ${fmtD(inflation * 100, 0)}% healthcare inflation</div>
+      <div class="sub">Including ${fmtD(inflation * 100, 0)}% annual healthcare cost growth</div>
     </div>`;
 
   const pre65Note = userAge < 65
@@ -1549,7 +1555,7 @@ function renderMedicareProjection(): void {
 
   $('medicareSources').innerHTML = `
     <div style="background:var(--bg);border:1px solid var(--border);border-radius:10px;padding:1rem 1.25rem;margin-top:1rem;">
-      <div style="font-size:0.8rem;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:0.04em;margin-bottom:0.75rem;">IRMAA Income Brackets (2026)</div>
+      <div style="font-size:0.8rem;font-weight:600;color:var(--muted);text-transform:uppercase;letter-spacing:0.04em;margin-bottom:0.75rem;">IRMAA Income Brackets (${MEDICARE_PLANNING_BASELINE_LABEL})</div>
       <div style="font-size:0.82rem;color:var(--text);line-height:1.6;">
         IRMAA surcharges apply to Part B and Part D premiums when your MAGI (from 2 years prior) exceeds thresholds.
         Your current MAGI of <strong>$${fmt(magi)}</strong> ${irmaaInfo.total > 0 ? `triggers <span style="color:var(--red);">$${fmt(irmaaInfo.total)}/yr</span> in surcharges` : 'is <span style="color:var(--accent);">below the $106K threshold</span> — no surcharges'}.
@@ -1561,14 +1567,7 @@ function renderMedicareProjection(): void {
           <th style="text-align:right;padding:0.3rem 0.5rem;color:var(--muted);">Part D Extra</th>
           <th style="text-align:right;padding:0.3rem 0.5rem;color:var(--muted);">Total/yr</th>
         </tr></thead>
-        <tbody>${[
-          { maxMagi: 106000, partBSurcharge: 0, partDSurcharge: 0 },
-          { maxMagi: 133000, partBSurcharge: 972, partDSurcharge: 149 },
-          { maxMagi: 167000, partBSurcharge: 2434, partDSurcharge: 385 },
-          { maxMagi: 200000, partBSurcharge: 3895, partDSurcharge: 622 },
-          { maxMagi: 500000, partBSurcharge: 5356, partDSurcharge: 858 },
-          { maxMagi: Infinity, partBSurcharge: 5965, partDSurcharge: 943 },
-        ].map((b, i, arr) => {
+        <tbody>${IRMAA_BRACKETS.map((b, i, arr) => {
           const prev = i > 0 ? arr[i - 1].maxMagi : 0;
           const label = b.maxMagi === Infinity ? '> $500K' : (i === 0 ? `≤ $${fmt(b.maxMagi)}` : `$${fmt(prev + 1)} – $${fmt(b.maxMagi)}`);
           const active = magi <= b.maxMagi && (i === 0 || magi > arr[i - 1].maxMagi);

--- a/src/render/investment-income.ts
+++ b/src/render/investment-income.ts
@@ -4,7 +4,7 @@ import { fmt, fmtD, fmtK } from '../utils/format';
 import { holdings, yieldCache } from '../state/store';
 import { getHoldingYield } from '../state/income';
 import { getCompositeSplit } from '../calc/allocation';
-import { FPL_2025 } from '../constants/aca';
+import { ACA_FPL_BASELINE, ACA_PLANNING_BASELINE_LABEL } from '../constants/aca';
 
 interface IncomeItem {
   ticker: string;
@@ -40,7 +40,7 @@ export function renderInvestmentIncome(): void {
     $('yieldFreshness').style.color = 'var(--muted)';
   }
 
-  const cliffAmt = FPL_2025 * 4;
+  const cliffAmt = ACA_FPL_BASELINE * 4;
 
   // Calculate income by account and holding
   const byAccount: Record<AccountType, IncomeItem[]> = { roth: [], hsa: [], ira: [], taxable: [] };
@@ -134,7 +134,7 @@ export function renderInvestmentIncome(): void {
           <div style="font-size:0.75rem;text-transform:uppercase;font-weight:600;color:var(--muted);letter-spacing:0.04em;margin-bottom:0.25rem;">Roth Conversion Room (under ACA cliff)</div>
           <div style="font-size:0.85rem;color:var(--muted);">
             Retirement MAGI is modeled as investment income only. Current MAGI-relevant investment income is <strong style="color:var(--text)">$${fmt(Math.round(totalMagi))}</strong>.
-            ACA cliff at $${fmt(Math.round(cliffAmt))}.
+            ACA cliff at $${fmt(Math.round(cliffAmt))} on the ${ACA_PLANNING_BASELINE_LABEL}.
           </div>
         </div>
         <div style="text-align:right;">

--- a/tests/calc/aca.test.ts
+++ b/tests/calc/aca.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { getAcaContributionPct, calcAcaSubsidy, calcAcaSubsidyForYear, estimateBenchmarkPremium, getAcaCliff } from '../../src/calc/aca';
-import { FPL_2025 } from '../../src/constants/aca';
+import { ACA_FPL_BASELINE } from '../../src/constants/aca';
 
 describe('getAcaContributionPct', () => {
   it('returns null below 100% FPL', () => {
@@ -8,19 +8,19 @@ describe('getAcaContributionPct', () => {
   });
 
   it('returns null above 400% FPL', () => {
-    expect(getAcaContributionPct(FPL_2025 * 4 + 1)).toBeNull();
+    expect(getAcaContributionPct(ACA_FPL_BASELINE * 4 + 1)).toBeNull();
   });
 
   it('returns ~2.1% at 100% FPL', () => {
-    expect(getAcaContributionPct(FPL_2025)).toBeCloseTo(0.021, 3);
+    expect(getAcaContributionPct(ACA_FPL_BASELINE)).toBeCloseTo(0.021, 3);
   });
 
   it('returns 9.96% at 300-400% FPL', () => {
-    expect(getAcaContributionPct(FPL_2025 * 3.5)).toBeCloseTo(0.0996, 3);
+    expect(getAcaContributionPct(ACA_FPL_BASELINE * 3.5)).toBeCloseTo(0.0996, 3);
   });
 
   it('interpolates between breakpoints', () => {
-    const pct = getAcaContributionPct(FPL_2025 * 1.5);
+    const pct = getAcaContributionPct(ACA_FPL_BASELINE * 1.5);
     expect(pct).not.toBeNull();
     expect(pct!).toBeGreaterThan(0.021);
     expect(pct!).toBeLessThan(0.066);
@@ -37,7 +37,7 @@ describe('calcAcaSubsidy', () => {
   });
 
   it('cliff: not eligible above 400% FPL', () => {
-    const cliff = FPL_2025 * 4;
+    const cliff = ACA_FPL_BASELINE * 4;
     const result = calcAcaSubsidy(cliff + 1, 50);
     expect(result.eligible).toBe(false);
     expect(result.medicaidEligible).toBe(false);
@@ -45,20 +45,20 @@ describe('calcAcaSubsidy', () => {
   });
 
   it('provides subsidy just below cliff', () => {
-    const justBelow = FPL_2025 * 3.99;
+    const justBelow = ACA_FPL_BASELINE * 3.99;
     const result = calcAcaSubsidy(justBelow, 50);
     expect(result.eligible).toBe(true);
     expect(result.subsidy).toBeGreaterThan(0);
   });
 
   it('subsidy is higher for lower incomes', () => {
-    const low = calcAcaSubsidy(FPL_2025 * 1.5, 50);
-    const high = calcAcaSubsidy(FPL_2025 * 3.5, 50);
+    const low = calcAcaSubsidy(ACA_FPL_BASELINE * 1.5, 50);
+    const high = calcAcaSubsidy(ACA_FPL_BASELINE * 3.5, 50);
     expect(low.subsidy).toBeGreaterThan(high.subsidy);
   });
 
   it('net premium is gold minus subsidy', () => {
-    const result = calcAcaSubsidy(FPL_2025 * 2.0, 50);
+    const result = calcAcaSubsidy(ACA_FPL_BASELINE * 2.0, 50);
     expect(result.netPremium).toBeCloseTo(result.goldPremium - result.subsidy, 0);
   });
 
@@ -86,8 +86,8 @@ describe('estimateBenchmarkPremium', () => {
 
 describe('getAcaCliff', () => {
   it('returns 400% of FPL', () => {
-    expect(getAcaCliff()).toBe(FPL_2025 * 4);
-    expect(getAcaCliff()).toBe(62600);
+    expect(getAcaCliff()).toBe(ACA_FPL_BASELINE * 4);
+    expect(getAcaCliff()).toBe(64200);
   });
 
   it('inflates the cliff over time', () => {

--- a/tests/calc/tax.test.ts
+++ b/tests/calc/tax.test.ts
@@ -9,7 +9,7 @@ import {
   getMarginalRate,
   getTopOfOrdinaryBracketGrossIncome,
 } from '../../src/calc/tax';
-import { STANDARD_DEDUCTION } from '../../src/constants/tax';
+import { STANDARD_DEDUCTION_BASELINE } from '../../src/constants/tax';
 
 describe('calcProgressiveTax', () => {
   it('returns zero tax for income at or below standard deduction', () => {
@@ -131,7 +131,7 @@ describe('calcTaxableSocialSecurity', () => {
 
 describe('inflation-adjusted bracket helpers', () => {
   it('inflates the standard deduction over time', () => {
-    expect(getInflationAdjustedStandardDeduction(10, 0.03)).toBeCloseTo(STANDARD_DEDUCTION * Math.pow(1.03, 10), 6);
+    expect(getInflationAdjustedStandardDeduction(10, 0.03)).toBeCloseTo(STANDARD_DEDUCTION_BASELINE * Math.pow(1.03, 10), 6);
   });
 
   it('inflates the gross-income target for the top of the 22% bracket', () => {


### PR DESCRIPTION
## Summary
- add a shared 2026 planning-baseline module for cross-cutting threshold growth assumptions
- rename fixed-year tax and ACA constants to baseline-oriented names and route calculators through the shared helpers
- update healthcare and tax UI copy to describe the values as planning baselines rather than exact filing-year law

## Testing
- npm test
- npm run build

Closes #8