### PR TITLE
Implement FP-103 taxable income estimates

### DIFF
--- a/src/calc/tax.ts
+++ b/src/calc/tax.ts
@@ -3,13 +3,16 @@ import {
   ADDITIONAL_MEDICARE_THRESHOLD_SINGLE,
   LTCG_TAX_BRACKETS_BASELINE,
   MEDICARE_PAYROLL_RATE,
+  NET_INVESTMENT_INCOME_TAX_RATE,
+  NET_INVESTMENT_INCOME_TAX_THRESHOLD_MARRIED,
+  NET_INVESTMENT_INCOME_TAX_THRESHOLD_SINGLE,
   ORDINARY_TAX_BRACKETS_BASELINE,
   SOCIAL_SECURITY_PAYROLL_RATE,
   SOCIAL_SECURITY_WAGE_BASE_BASELINE,
   STANDARD_DEDUCTION_BASELINE,
 } from '../constants/tax';
 import { PLANNING_GROWTH_RATES, scalePlanningAmount, scalePlanningBrackets } from '../constants/planning';
-import type { TaxBracket, TaxResult } from '../types';
+import type { FilingStatus, TaxBracket, TaxResult } from '../types';
 
 const SS_BASE_AMOUNT_SINGLE = 25000;
 const SS_ADJUSTED_BASE_SINGLE = 34000;
@@ -171,6 +174,50 @@ export function calcFederalIncomeTax(
     capitalGainsTax,
     totalTax: ordinaryTax + capitalGainsTax,
     effectiveRate: grossIncome > 0 ? (ordinaryTax + capitalGainsTax) / grossIncome : 0,
+  };
+}
+
+export function getNetInvestmentIncomeTaxThreshold(filingStatus: FilingStatus = 'single'): number {
+  return filingStatus === 'married'
+    ? NET_INVESTMENT_INCOME_TAX_THRESHOLD_MARRIED
+    : NET_INVESTMENT_INCOME_TAX_THRESHOLD_SINGLE;
+}
+
+export function calcNetInvestmentIncomeTax(
+  magi: number,
+  netInvestmentIncome: number,
+  filingStatus: FilingStatus = 'single',
+): TaxResult {
+  const threshold = getNetInvestmentIncomeTaxThreshold(filingStatus);
+  const taxableBase = Math.min(
+    Math.max(magi - threshold, 0),
+    Math.max(netInvestmentIncome, 0),
+  );
+  const tax = taxableBase * NET_INVESTMENT_INCOME_TAX_RATE;
+  return {
+    tax,
+    effectiveRate: netInvestmentIncome > 0 ? tax / netInvestmentIncome : 0,
+  };
+}
+
+export function estimateForeignTaxCredit(
+  foreignTaxPaid: number,
+  foreignSourceIncome: number,
+  totalTaxableIncome: number,
+  regularFederalTax: number,
+): {
+  limitation: number;
+  allowableCredit: number;
+  disallowedCredit: number;
+} {
+  const limitation = totalTaxableIncome > 0
+    ? regularFederalTax * Math.min(Math.max(foreignSourceIncome, 0) / totalTaxableIncome, 1)
+    : 0;
+  const allowableCredit = Math.min(Math.max(foreignTaxPaid, 0), limitation);
+  return {
+    limitation,
+    allowableCredit,
+    disallowedCredit: Math.max(foreignTaxPaid - allowableCredit, 0),
   };
 }
 

--- a/src/constants/foreign-tax.ts
+++ b/src/constants/foreign-tax.ts
@@ -1,0 +1,12 @@
+export const FOREIGN_TAX_CREDIT_RATIO_BY_TICKER: Record<string, number> = {
+  VXUS: 0.0711,
+  VEA: 0.0646,
+  VWO: 0.1093,
+  VEU: 0.0826,
+  VTIAX: 0.0711,
+  VFWAX: 0.0826,
+  BNDX: 0.0017,
+};
+
+export const DEFAULT_FOREIGN_TAX_CREDIT_RATIO_STOCK = 0.08;
+export const DEFAULT_FOREIGN_TAX_CREDIT_RATIO_BOND = 0.002;

--- a/src/constants/tax.ts
+++ b/src/constants/tax.ts
@@ -18,6 +18,9 @@ export const SOCIAL_SECURITY_PAYROLL_RATE = 0.062;
 export const MEDICARE_PAYROLL_RATE = 0.0145;
 export const ADDITIONAL_MEDICARE_RATE = 0.009;
 export const ADDITIONAL_MEDICARE_THRESHOLD_SINGLE = 200000;
+export const NET_INVESTMENT_INCOME_TAX_RATE = 0.038;
+export const NET_INVESTMENT_INCOME_TAX_THRESHOLD_SINGLE = 200000;
+export const NET_INVESTMENT_INCOME_TAX_THRESHOLD_MARRIED = 250000;
 
 // 2026 planning baseline long-term capital gains brackets (single filer), taxable income basis
 export const LTCG_TAX_BRACKETS_BASELINE: TaxBracket[] = [

--- a/src/render/investment-income.ts
+++ b/src/render/investment-income.ts
@@ -5,6 +5,8 @@ import { holdings, yieldCache } from '../state/store';
 import { getHoldingYield } from '../state/income';
 import { getCompositeSplit } from '../calc/allocation';
 import { ACA_FPL_BASELINE, ACA_PLANNING_BASELINE_LABEL } from '../constants/aca';
+import { DEFAULT_FOREIGN_TAX_CREDIT_RATIO_BOND, DEFAULT_FOREIGN_TAX_CREDIT_RATIO_STOCK, FOREIGN_TAX_CREDIT_RATIO_BY_TICKER } from '../constants/foreign-tax';
+import { calcFederalIncomeTax, calcNetInvestmentIncomeTax, estimateForeignTaxCredit } from '../calc/tax';
 
 interface IncomeItem {
   ticker: string;
@@ -63,12 +65,24 @@ export function renderInvestmentIncome(): void {
     }
   }
 
+  const plannerState = (() => {
+    try {
+      return JSON.parse(localStorage.getItem('fire_planner_inputs') || '{}') as { annualIncome?: number | string; filingStatus?: string };
+    } catch {
+      return {};
+    }
+  })();
+  const plannerEarnedIncome = Number(plannerState.annualIncome || 0) || 0;
+  const filingStatus = plannerState.filingStatus === 'married' ? 'married' : 'single';
+
   // Qualified vs ordinary
-  let qualifiedIncome = 0, ordinaryIncome = 0;
+  let qualifiedIncome = 0, ordinaryIncome = 0, foreignSourceIncome = 0, foreignTaxPaid = 0;
   for (const item of byAccount.taxable) {
     if (item.isMuni) continue;
     const h = holdings.find(hh => hh.ticker === item.ticker && hh.account === 'taxable');
     const split = h ? getCompositeSplit(h) : null;
+    const ratio = FOREIGN_TAX_CREDIT_RATIO_BY_TICKER[item.ticker.toUpperCase()]
+      ?? (item.category === 'bond' ? DEFAULT_FOREIGN_TAX_CREDIT_RATIO_BOND : DEFAULT_FOREIGN_TAX_CREDIT_RATIO_STOCK);
     if (split) {
       const stockPct = (split.us_stock || 0) + (split.intl_stock || 0);
       const muniPct = split.muni || 0;
@@ -76,10 +90,20 @@ export function renderInvestmentIncome(): void {
       qualifiedIncome += item.income * stockPct;
       ordinaryIncome += item.income * bondPct;
       muniIncome += item.income * muniPct;
+      foreignSourceIncome += item.income * (split.intl_stock || 0);
+      foreignTaxPaid += item.income * (split.intl_stock || 0) * ratio;
     } else if (['bond', 'reit', 'cash'].includes(item.category)) {
       ordinaryIncome += item.income;
+      if (item.category === 'bond' && item.ticker.toUpperCase() === 'BNDX') {
+        foreignSourceIncome += item.income;
+        foreignTaxPaid += item.income * ratio;
+      }
     } else {
       qualifiedIncome += item.income;
+      if (item.category === 'intl_stock') {
+        foreignSourceIncome += item.income;
+        foreignTaxPaid += item.income * ratio;
+      }
     }
   }
 
@@ -88,6 +112,14 @@ export function renderInvestmentIncome(): void {
   const shelteredIncome = totalIncome - magiFromDividends;
   const totalMagi = magiFromDividends;
   const conversionRoom = Math.max(cliffAmt - totalMagi - 1000, 0);
+  const estimatedFederalTax = calcFederalIncomeTax(plannerEarnedIncome + ordinaryIncome, qualifiedIncome).totalTax;
+  const ftc = estimateForeignTaxCredit(
+    foreignTaxPaid,
+    foreignSourceIncome,
+    plannerEarnedIncome + ordinaryIncome + qualifiedIncome,
+    estimatedFederalTax,
+  );
+  const niit = calcNetInvestmentIncomeTax(plannerEarnedIncome + ordinaryIncome + qualifiedIncome, taxableIncome, filingStatus);
 
   // Summary stats
   const summaryHtml = `
@@ -124,6 +156,21 @@ export function renderInvestmentIncome(): void {
         <div class="stat-label">Ordinary Income (taxed as income)</div>
         <div class="stat-value" style="color:${ordinaryIncome > 0 ? 'var(--red)' : 'var(--accent)'}">$${fmt(Math.round(ordinaryIncome))}</div>
       </div>
+      ${foreignSourceIncome > 0 ? `<div class="stat-card">
+        <div class="stat-label">Intl Dividend Income</div>
+        <div class="stat-value" style="color:var(--blue)">$${fmt(Math.round(foreignSourceIncome))}</div>
+        <div style="font-size:0.65rem;color:var(--muted);margin-top:2px;">Estimated foreign-source income from taxable international holdings</div>
+      </div>` : ''}
+      ${foreignTaxPaid > 0 ? `<div class="stat-card">
+        <div class="stat-label">Estimated FTC</div>
+        <div class="stat-value" style="color:var(--accent)">$${fmt(Math.round(ftc.allowableCredit))}</div>
+        <div style="font-size:0.65rem;color:var(--muted);margin-top:2px;">$${fmt(Math.round(foreignTaxPaid))} paid, $${fmt(Math.round(ftc.limitation))} limit</div>
+      </div>` : ''}
+      ${niit.tax > 0 ? `<div class="stat-card">
+        <div class="stat-label">Estimated NIIT</div>
+        <div class="stat-value" style="color:var(--red)">$${fmt(Math.round(niit.tax))}</div>
+        <div style="font-size:0.65rem;color:var(--muted);margin-top:2px;">3.8% surtax using planner filing status and earned-income baseline</div>
+      </div>` : ''}
     </div>`;
 
   // Conversion room callout
@@ -136,6 +183,9 @@ export function renderInvestmentIncome(): void {
             Retirement MAGI is modeled as investment income only. Current MAGI-relevant investment income is <strong style="color:var(--text)">$${fmt(Math.round(totalMagi))}</strong>.
             ACA cliff at $${fmt(Math.round(cliffAmt))} on the ${ACA_PLANNING_BASELINE_LABEL}.
           </div>
+          ${(foreignTaxPaid > 0 || niit.tax > 0) ? `<div style="font-size:0.78rem;color:var(--muted);margin-top:0.45rem;">
+            Tax estimates assume qualified dividends remain eligible for long-term capital-gains rates, NIIT uses the current planner filing status and earned-income baseline, and the foreign tax credit is estimated from taxable international dividends subject to an FTC limitation.
+          </div>` : ''}
         </div>
         <div style="text-align:right;">
           <div style="font-size:1.4rem;font-weight:700;color:${conversionRoom > 10000 ? 'var(--accent)' : conversionRoom > 0 ? 'var(--orange)' : 'var(--red)'}">

--- a/tests/calc/tax.test.ts
+++ b/tests/calc/tax.test.ts
@@ -2,10 +2,13 @@ import { describe, it, expect } from 'vitest';
 import {
   calcFederalIncomeTax,
   calcLongTermCapitalGainsTax,
+  calcNetInvestmentIncomeTax,
   calcPayrollTax,
   calcProgressiveTax,
   calcTaxableSocialSecurity,
+  estimateForeignTaxCredit,
   getInflationAdjustedStandardDeduction,
+  getNetInvestmentIncomeTaxThreshold,
   getMarginalRate,
   getTopOfOrdinaryBracketGrossIncome,
 } from '../../src/calc/tax';
@@ -95,6 +98,30 @@ describe('calcFederalIncomeTax', () => {
     const currentYearTax = calcFederalIncomeTax(80000, 20000).totalTax;
     const laterYearTax = calcFederalIncomeTax(80000, 20000, 10, 0.03).totalTax;
     expect(laterYearTax).toBeLessThan(currentYearTax);
+  });
+});
+
+describe('net investment income tax', () => {
+  it('returns zero below the threshold', () => {
+    expect(calcNetInvestmentIncomeTax(150000, 10000).tax).toBe(0);
+  });
+
+  it('uses the lower of excess MAGI and net investment income', () => {
+    expect(calcNetInvestmentIncomeTax(220000, 10000).tax).toBeCloseTo(380, 6);
+    expect(calcNetInvestmentIncomeTax(300000, 10000).tax).toBeCloseTo(380, 6);
+  });
+
+  it('uses a higher threshold for married filers', () => {
+    expect(getNetInvestmentIncomeTaxThreshold('married')).toBeGreaterThan(getNetInvestmentIncomeTaxThreshold('single'));
+  });
+});
+
+describe('foreign tax credit estimate', () => {
+  it('limits the allowable credit to the FTC limitation', () => {
+    const result = estimateForeignTaxCredit(1200, 10000, 60000, 6000);
+    expect(result.limitation).toBeCloseTo(1000, 6);
+    expect(result.allowableCredit).toBeCloseTo(1000, 6);
+    expect(result.disallowedCredit).toBeCloseTo(200, 6);
   });
 });
 


### PR DESCRIPTION
## Summary
- add NIIT and foreign tax credit estimation helpers to the tax module with test coverage
- introduce conservative foreign-tax pass-through assumptions for common international funds and category defaults
- surface estimated international dividend income, FTC, and NIIT in the investment-income view with an assumptions note

## Testing
- npm test
- npm run build

Closes #6