### PR TITLE
Add symbol refresh workflow improvements

### DIFF
--- a/docs/2026-planning-backlog.md
+++ b/docs/2026-planning-backlog.md
@@ -1,0 +1,323 @@
+# FIRE Planner 2026 Backlog
+
+Planning assumptions for this backlog:
+
+- Use **2026** as the baseline planning year.
+- Do **not** add a user-facing tax-year selector.
+- Model future years with reasonable inflation-style adjustments where exact law is unknown.
+- Favor educational planning accuracy over tax-form exactness.
+
+## Prioritized Tickets
+
+### FP-101: Centralize 2026 planning assumptions and forward-scaling rules
+
+**Priority:** P0
+
+**Why**
+
+Tax, ACA, Medicare, and retirement thresholds are currently spread across constants and are partly tied to specific calendar-year labels. The app needs one planning baseline and one clear rule for how future years evolve.
+
+**Scope**
+
+- Add a single planning assumptions layer for 2026 baseline values.
+- Define forward-scaling rules for brackets, deductions, ACA/FPL thresholds, IRMAA thresholds, and RMD assumptions.
+- Replace hardcoded year-specific labels in the UI where they imply exact filing-year precision.
+
+**Acceptance criteria**
+
+- Core modules read thresholds from one shared planning assumptions source.
+- The app can project future thresholds from 2026 without a tax-year selector.
+- User-facing copy describes values as planning assumptions, not filing-year guarantees.
+
+**Likely files**
+
+- `src/constants/tax.ts`
+- `src/constants/aca.ts`
+- `src/constants/medicare.ts`
+- `src/calc/tax.ts`
+- `src/calc/aca.ts`
+- `src/calc/medicare.ts`
+
+### FP-102: Add household profile inputs
+
+**Priority:** P0
+
+**Why**
+
+Single-filer assumptions materially distort real retirement, ACA, Medicare, and tax planning for couples and families.
+
+**Scope**
+
+- Add filing status.
+- Add spouse age, spouse earned income, spouse retirement age, and spouse Social Security inputs.
+- Add household size for ACA planning.
+- Persist the new fields in local storage.
+
+**Acceptance criteria**
+
+- Planner, healthcare, and conversion views can run for single and married households.
+- Household size changes ACA/FPL outputs.
+- Spouse Social Security and spouse age flow into retirement and drawdown outputs.
+
+**Likely files**
+
+- `src/types.ts`
+- `src/main.ts`
+- `src/state/store.ts`
+- `src/calc/fire.ts`
+- `src/calc/aca.ts`
+- `src/calc/medicare.ts`
+
+### FP-103: Upgrade the tax engine for taxable-account realism
+
+**Priority:** P0
+
+**Why**
+
+The current tool is directionally useful, but the next level of planning value comes from modeling what taxable investors actually face.
+
+**Scope**
+
+- Separate ordinary income, qualified dividends, and long-term capital gains.
+- Add foreign tax credit estimates for taxable international funds.
+- Add NIIT estimation where applicable.
+- Distinguish sheltered accounts from taxable accounts more explicitly in projections.
+
+**Acceptance criteria**
+
+- Tax calculations expose ordinary-income tax, capital-gain tax, NIIT, and FTC components.
+- International taxable holdings can reduce estimated federal tax via FTC, subject to a modeled limit.
+- Planner outputs explain when qualified dividends and capital gains are being assumed.
+
+**Likely files**
+
+- `src/calc/tax.ts`
+- `src/calc/fire.ts`
+- `src/state/income.ts`
+- `src/render/investment-income.ts`
+- `src/render/planner.ts`
+
+### FP-104: Track embedded gains and cost-basis sensitivity in taxable accounts
+
+**Priority:** P1
+
+**Why**
+
+Withdrawal planning and tax-efficiency guidance are weaker when the tool knows value but not unrealized gains.
+
+**Scope**
+
+- Use existing holding cost basis data to estimate unrealized gains by taxable holding.
+- Surface gain percentage and tax sensitivity in the portfolio UI.
+- Feed embedded gains into drawdown and recommendation logic.
+
+**Acceptance criteria**
+
+- Taxable holdings show unrealized gain or loss estimates.
+- Drawdown and recommendation views can distinguish high-basis from low-basis taxable assets.
+- Portfolio suggestions avoid treating all taxable sales as equivalent.
+
+**Likely files**
+
+- `src/types.ts`
+- `src/render/holdings.ts`
+- `src/render/suggestions.ts`
+- `src/calc/tax-efficiency.ts`
+- `src/main.ts`
+
+### FP-105: Replace static withdrawal order with a yearly tax-aware optimizer
+
+**Priority:** P0
+
+**Why**
+
+A fixed withdrawal sequence leaves too much value on the table, especially for early retirees balancing ACA, conversions, and future RMDs.
+
+**Scope**
+
+- Optimize annual withdrawals across taxable, IRA, Roth, and HSA.
+- Allow bracket filling up to a target marginal rate.
+- Coordinate taxable sales, ordinary income, Roth conversions, and Social Security start dates.
+
+**Acceptance criteria**
+
+- Drawdown results show yearly source mix instead of only a static order.
+- The optimizer can compare at least two strategies and explain why one wins.
+- Year-by-year outputs include taxable income, tax paid, and account source mix.
+
+**Likely files**
+
+- `src/calc/drawdown.ts`
+- `src/main.ts`
+- `src/render/planner.ts`
+
+### FP-106: Rebuild the Roth conversion calculator around bracket management
+
+**Priority:** P0
+
+**Why**
+
+Roth conversions are most valuable when coordinated with taxable income, ACA subsidies, IRMAA, and future RMDs rather than treated as a narrow scenario tool.
+
+**Scope**
+
+- Let users set a marginal-rate ceiling rather than only strategy presets.
+- Model the interaction among conversions, ACA MAGI, Social Security taxation, and future RMD pressure.
+- Compare no-conversion, moderate conversion, and aggressive conversion paths using the same tax engine.
+
+**Acceptance criteria**
+
+- Conversion results show why the suggested amount is optimal under the tool's assumptions.
+- Scenario tables show tax paid now versus tax avoided later.
+- ACA and future Medicare effects are visible in the output.
+
+**Likely files**
+
+- `src/main.ts`
+- `src/calc/drawdown.ts`
+- `src/calc/tax.ts`
+- `src/calc/aca.ts`
+- `src/calc/medicare.ts`
+
+### FP-107: Add Social Security claiming optimization
+
+**Priority:** P1
+
+**Why**
+
+Claim timing is one of the highest-dollar retirement decisions and should not be reduced to a single manual input.
+
+**Scope**
+
+- Add claiming-age sweeps.
+- Model spouse and survivor effects for married households.
+- Show break-even framing and lifetime after-tax income impact.
+
+**Acceptance criteria**
+
+- The planner can compare multiple claim ages side by side.
+- Married-household mode reflects survivor implications.
+- Outputs clearly state the assumptions behind the recommendation.
+
+**Likely files**
+
+- `src/calc/fire.ts`
+- `src/calc/drawdown.ts`
+- `src/main.ts`
+- `src/render/planner.ts`
+
+### FP-108: Improve healthcare modeling with location-aware inputs
+
+**Priority:** P1
+
+**Why**
+
+ACA and pre-Medicare healthcare costs vary too much by geography and benchmark pricing for a single generic table to be enough.
+
+**Scope**
+
+- Add state and county or ZIP proxy inputs.
+- Allow manual benchmark silver premium override.
+- Distinguish federal planning assumptions from user-entered local premium data.
+
+**Acceptance criteria**
+
+- Users can override benchmark premiums without changing core formulas.
+- Healthcare outputs clearly show what came from assumptions versus user input.
+- ACA sensitivity tables remain usable with custom premium inputs.
+
+**Likely files**
+
+- `src/main.ts`
+- `src/calc/aca.ts`
+- `src/render/planner.ts`
+
+### FP-109: Add stress testing and guardrail spending analysis
+
+**Priority:** P1
+
+**Why**
+
+A single deterministic return path is useful, but it hides sequence risk and spending flexibility.
+
+**Scope**
+
+- Add simple historical stress scenarios or Monte Carlo-lite analysis.
+- Add guardrail spending rules for portfolio drawdowns.
+- Show probability-style framing without pretending to predict exact outcomes.
+
+**Acceptance criteria**
+
+- Users can compare baseline, weak-market, and strong-market paths.
+- Drawdown results can model spending reductions after poor returns.
+- The UI explains that scenario analysis is heuristic, not a forecast.
+
+**Likely files**
+
+- `src/calc/drawdown.ts`
+- `src/main.ts`
+- `src/render/planner.ts`
+
+### FP-110: Make recommendations auditable
+
+**Priority:** P1
+
+**Why**
+
+Planning tools earn trust when users can see the assumptions behind the advice.
+
+**Scope**
+
+- Add explanation panels for portfolio, tax-efficiency, healthcare, and conversion recommendations.
+- Show which thresholds, tax rates, and income assumptions drove each recommendation.
+- Highlight when an answer is highly sensitive to uncertain inputs.
+
+**Acceptance criteria**
+
+- Every major recommendation has a visible "why this" explanation.
+- The explanation references the main assumptions used.
+- Sensitive outputs call out uncertainty instead of presenting false precision.
+
+**Likely files**
+
+- `src/render/suggestions.ts`
+- `src/render/tax-efficiency.ts`
+- `src/render/investment-income.ts`
+- `src/main.ts`
+
+### FP-111: Expand tests around planning assumptions and tax interactions
+
+**Priority:** P0
+
+**Why**
+
+The planned work increases coupling among taxes, healthcare, drawdown, and account types. That needs stronger test coverage before behavior changes start shipping.
+
+**Scope**
+
+- Add tests for household profiles.
+- Add tests for qualified dividends, LTCG, FTC, and NIIT interactions.
+- Add tests for conversion and drawdown scenarios that cross ACA and Medicare thresholds.
+
+**Acceptance criteria**
+
+- New planning rules ship with unit tests for edge cases and representative scenarios.
+- Regressions in threshold scaling and tax coordination are caught by CI.
+- At least one end-to-end scenario test covers the main retirement flow.
+
+**Likely files**
+
+- `tests/calc/tax.test.ts`
+- `tests/calc/fire.test.ts`
+- `tests/calc/drawdown.test.ts`
+- `tests/calc/aca.test.ts`
+
+## Suggested Delivery Order
+
+1. `FP-101` assumptions layer
+2. `FP-102` household profile
+3. `FP-103` tax engine realism
+4. `FP-111` test expansion in parallel with the above
+5. `FP-105` withdrawal optimizer
+6. `FP-106` Roth conversion rebuild
+7. `FP-104`, `FP-107`, `FP-108`, `FP-109`, `FP-110`

--- a/src/calc/symbol-data.ts
+++ b/src/calc/symbol-data.ts
@@ -1,0 +1,368 @@
+import type { CategoryKey, CompositeSplit } from '../types';
+import { COMPOSITE_FUNDS } from '../constants/tickers';
+
+export interface SymbolLookupResult {
+  yield: number | null;
+  price: number | null;
+  name: string | null;
+  allocation: CompositeSplit | null;
+  assetClass?: string | null;
+  etfCategory?: string | null;
+  detectedCategory?: CategoryKey | null;
+  expenseRatio?: number | null;
+  sources?: string[];
+}
+
+export interface DealchartsSearchResult {
+  key?: string;
+  nameShort?: string;
+  nameLong?: string;
+  assetClass?: string;
+  sector?: string;
+  facts_url?: string;
+}
+
+export interface DealchartsHolding {
+  value_usd?: number;
+  pct_val?: number;
+  asset_cat?: string;
+  inv_country?: string;
+  title?: string;
+  issuer_name?: string;
+  issuer_cat?: string;
+}
+
+export interface DealchartsFundFacts {
+  name?: string;
+  holdings?: DealchartsHolding[];
+  summary?: {
+    total_value_usd?: number;
+    by_asset_category?: Record<string, { total_value_usd?: number }>;
+  };
+}
+
+export interface EodhdEodBar {
+  date?: string;
+  close?: number | string;
+  adjusted_close?: number | string;
+  Close?: number | string;
+  Adjusted_close?: number | string;
+}
+
+export function emptySymbolLookupResult(): SymbolLookupResult {
+  return {
+    yield: null,
+    price: null,
+    name: null,
+    allocation: null,
+    assetClass: null,
+    etfCategory: null,
+    detectedCategory: null,
+    expenseRatio: null,
+    sources: [],
+  };
+}
+
+function parsePercent(value: unknown): number | null {
+  if (value == null) return null;
+  const match = String(value).match(/([\d.]+)/);
+  return match ? parseFloat(match[1]) : null;
+}
+
+function parseNumber(value: unknown): number | null {
+  if (value == null) return null;
+  if (typeof value === 'number') return Number.isFinite(value) ? value : null;
+  const cleaned = String(value).replace(/[$,%\s,]/g, '');
+  const parsed = parseFloat(cleaned);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeAllocation(split: Record<string, number> | null): CompositeSplit | null {
+  if (!split) return null;
+  const positiveEntries = Object.entries(split).filter(([, value]) => value > 0);
+  const total = positiveEntries.reduce((sum, [, value]) => sum + value, 0);
+  if (total <= 0) return null;
+  return positiveEntries.reduce((acc, [key, value]) => {
+    acc[key] = value / total;
+    return acc;
+  }, {} as CompositeSplit);
+}
+
+function inferAllocationFromFundLabel(assetClass: string | null, etfCategory: string | null): CompositeSplit | null {
+  if (assetClass !== 'Asset Allocation' || !etfCategory) return null;
+  const cat = etfCategory.toLowerCase();
+  if (cat.includes('aggressive') || cat.includes('85') || cat.includes('80')) return { us_stock: 0.48, intl_stock: 0.32, bond: 0.16, cash: 0.04 };
+  if (cat.includes('growth') || cat.includes('60')) return { us_stock: 0.36, intl_stock: 0.24, bond: 0.32, cash: 0.08 };
+  if (cat.includes('moderate') || cat.includes('50') || cat.includes('balanced')) return { us_stock: 0.30, intl_stock: 0.20, bond: 0.35, cash: 0.15 };
+  if (cat.includes('conservative') || cat.includes('30') || cat.includes('40')) return { us_stock: 0.24, intl_stock: 0.16, bond: 0.42, cash: 0.18 };
+  if (cat.includes('income') || cat.includes('20')) return { us_stock: 0.12, intl_stock: 0.08, bond: 0.56, cash: 0.24 };
+  return null;
+}
+
+function detectCategory(assetClass: string | null, etfCategory: string | null): CategoryKey | null {
+  if (assetClass === 'Fixed Income') return 'bond';
+  if (assetClass === 'Equity') {
+    return etfCategory && /international|foreign|emerging|global/i.test(etfCategory)
+      ? 'intl_stock'
+      : 'us_stock';
+  }
+  if (assetClass === 'Real Estate') return 'reit';
+  return null;
+}
+
+export function parseStockAnalysisOverview(ticker: string, data: any): SymbolLookupResult | null {
+  if (!data) return null;
+
+  let yld: number | null = null;
+  if (data.dividendYield != null) yld = parseFloat(data.dividendYield);
+  else if (data.dividend) {
+    const match = String(data.dividend).match(/([\d.]+)%/);
+    if (match) yld = parseFloat(match[1]);
+  }
+
+  let price: number | null = null;
+  if (data.nav != null) price = parseFloat(String(data.nav).replace(/[$,]/g, ''));
+  else if (data.price != null) price = parseFloat(String(data.price).replace(/[$,]/g, ''));
+
+  let name: string | null = null;
+  if (data.name) name = data.name;
+  else if (data.description) {
+    const firstSentence = String(data.description).split(/\.\s/)[0];
+    const nameMatch = firstSentence.match(/^(.+?)(?:\s+is\s|\s+designs\s|\s+provides\s|\s+develops\s|\s+operates\s|\s+manufactures\s)/i);
+    name = nameMatch ? nameMatch[1] : firstSentence.substring(0, 50);
+  }
+
+  let assetClass: string | null = null;
+  let etfCategory: string | null = null;
+  let expenseRatio: number | null = parsePercent(data.expenseRatio ?? data.expense_ratio ?? data.netExpenseRatio ?? data.net_expense_ratio);
+  const infoTable = data.infoTable;
+  if (Array.isArray(infoTable)) {
+    for (const item of infoTable) {
+      if (!Array.isArray(item)) continue;
+      const label = String(item[0] || '');
+      const normalizedLabel = label.toLowerCase();
+      if (label === 'Asset Class') assetClass = item[1];
+      if (label === 'Category') etfCategory = item[1];
+      if (item[1] && normalizedLabel.includes('expense') && normalizedLabel.includes('ratio')) {
+        expenseRatio = parsePercent(item[1]) ?? expenseRatio;
+      }
+    }
+  }
+
+  const allocation = COMPOSITE_FUNDS[ticker.toUpperCase()] || inferAllocationFromFundLabel(assetClass, etfCategory);
+  return {
+    yield: yld,
+    price,
+    name,
+    allocation,
+    assetClass,
+    etfCategory,
+    detectedCategory: detectCategory(assetClass, etfCategory),
+    expenseRatio,
+    sources: ['Stock Analysis overview'],
+  };
+}
+
+export function parseEodhdEodPrice(
+  payload: EodhdEodBar | EodhdEodBar[] | null | undefined,
+  source = 'EODHD end-of-day price',
+): SymbolLookupResult | null {
+  if (!payload) return null;
+  const series = Array.isArray(payload) ? payload : [payload];
+  const lastBar = series.filter(Boolean).at(-1);
+  const price = parseNumber(lastBar?.adjusted_close ?? lastBar?.close ?? lastBar?.Adjusted_close ?? lastBar?.Close);
+  if (price == null) return null;
+  return {
+    yield: null,
+    price,
+    name: null,
+    allocation: null,
+    assetClass: null,
+    etfCategory: null,
+    detectedCategory: null,
+    expenseRatio: null,
+    sources: [source],
+  };
+}
+
+export function mergeSymbolLookupResults(...parts: Array<SymbolLookupResult | null | undefined>): SymbolLookupResult {
+  const merged = emptySymbolLookupResult();
+  for (const part of parts) {
+    if (!part) continue;
+    if (part.yield != null) merged.yield = part.yield;
+    if (part.price != null) merged.price = part.price;
+    if (part.name) merged.name = part.name;
+    if (part.allocation) merged.allocation = part.allocation;
+    if (part.assetClass) merged.assetClass = part.assetClass;
+    if (part.etfCategory) merged.etfCategory = part.etfCategory;
+    if (part.detectedCategory) merged.detectedCategory = part.detectedCategory;
+    if (part.expenseRatio != null) merged.expenseRatio = part.expenseRatio;
+    if (part.sources?.length) {
+      merged.sources = [...new Set([...(merged.sources || []), ...part.sources])];
+    }
+  }
+  return merged;
+}
+
+function tokenize(value: string): string[] {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .split(' ')
+    .filter((token) => token.length >= 3);
+}
+
+export function buildDealchartsQueries(ticker: string, name?: string | null): string[] {
+  const queries = new Set<string>([ticker.toUpperCase()]);
+  const trimmedName = name?.trim();
+  if (trimmedName) {
+    queries.add(trimmedName);
+    if (!/\bfund\b/i.test(trimmedName)) queries.add(`${trimmedName} fund`);
+  }
+  return [...queries];
+}
+
+function scoreDealchartsResult(result: DealchartsSearchResult, ticker: string, name?: string | null): number {
+  const resultName = `${result.nameLong || ''} ${result.nameShort || ''}`.trim().toLowerCase();
+  const resultKey = (result.key || '').toLowerCase();
+  const resultTokens = new Set(tokenize(`${resultName} ${resultKey}`));
+  const targetTokens = new Set(tokenize(`${ticker} ${name || ''}`));
+  let score = 0;
+  for (const token of targetTokens) {
+    if (resultTokens.has(token)) score += 1;
+  }
+  if ((result.assetClass || '').toLowerCase() === 'fund' || (result.sector || '').toLowerCase() === 'fund') score += 1;
+  if (name && resultName.includes(name.toLowerCase())) score += 2;
+  return score;
+}
+
+export function pickDealchartsSearchResult(
+  results: DealchartsSearchResult[],
+  ticker: string,
+  name?: string | null,
+): DealchartsSearchResult | null {
+  if (!results.length) return null;
+  return [...results]
+    .filter((result) => !!result.facts_url)
+    .sort((left, right) => scoreDealchartsResult(right, ticker, name) - scoreDealchartsResult(left, ticker, name))[0] || null;
+}
+
+function isLikelyMunicipalDebt(name: string, holding?: DealchartsHolding): boolean {
+  const haystack = `${name} ${holding?.title || ''} ${holding?.issuer_name || ''} ${holding?.issuer_cat || ''}`.toLowerCase();
+  return /\bmuni|municipal|tax[- ]exempt|tax[- ]managed\b/.test(haystack);
+}
+
+function classifyHolding(name: string, holding: DealchartsHolding): CategoryKey | null {
+  const assetCat = (holding.asset_cat || '').toUpperCase();
+  const label = `${holding.title || ''} ${holding.issuer_name || ''} ${holding.issuer_cat || ''}`.toLowerCase();
+
+  if (/cash|money market|repurchase|treasury liquidity|settlement/.test(label)) return 'cash';
+  if (/reit|real estate/.test(label)) return 'reit';
+  if (assetCat === 'EC') return holding.inv_country && holding.inv_country !== 'US' ? 'intl_stock' : 'us_stock';
+  if (assetCat === 'DBT' || assetCat === 'ABS-MBS') return isLikelyMunicipalDebt(name, holding) ? 'muni' : 'bond';
+  return null;
+}
+
+function allocationFromHoldings(name: string, holdings: DealchartsHolding[]): CompositeSplit | null {
+  const totals: Record<string, number> = {};
+  let total = 0;
+
+  for (const holding of holdings) {
+    const category = classifyHolding(name, holding);
+    if (!category) continue;
+    const amount = holding.value_usd && holding.value_usd > 0 ? holding.value_usd : null;
+    if (amount == null) continue;
+    totals[category] = (totals[category] || 0) + amount;
+    total += amount;
+  }
+
+  if (total <= 0) return null;
+  return normalizeAllocation(totals);
+}
+
+function allocationFromSummary(name: string, facts: DealchartsFundFacts): CompositeSplit | null {
+  const byAssetCategory = facts.summary?.by_asset_category;
+  const total = facts.summary?.total_value_usd || 0;
+  if (!byAssetCategory || total <= 0) return null;
+
+  const equities = (byAssetCategory.EC?.total_value_usd || 0);
+  const debt = (byAssetCategory.DBT?.total_value_usd || 0) + (byAssetCategory['ABS-MBS']?.total_value_usd || 0);
+  const split: Record<string, number> = {};
+
+  if (equities > 0) {
+    if (/international|foreign|global|world|emerging|ex[- ]?us/.test(name.toLowerCase())) split.intl_stock = equities;
+    else split.us_stock = equities;
+  }
+  if (debt > 0) {
+    split[isLikelyMunicipalDebt(name) ? 'muni' : 'bond'] = debt;
+  }
+  return normalizeAllocation(split);
+}
+
+export function parseDealchartsFundFacts(ticker: string, facts: DealchartsFundFacts): SymbolLookupResult | null {
+  const name = facts.name || null;
+  const allocation = COMPOSITE_FUNDS[ticker.toUpperCase()]
+    || allocationFromHoldings(name || '', facts.holdings || [])
+    || allocationFromSummary(name || '', facts);
+
+  let assetClass: string | null = null;
+  if (allocation) {
+    const keys = Object.keys(allocation);
+    assetClass = keys.length > 1 ? 'Multi-Asset Fund' : keys[0] || null;
+  }
+
+  let detectedCategory: CategoryKey | null = null;
+  if (!allocation && name) {
+    if (/municipal|muni|tax[- ]exempt/.test(name.toLowerCase())) detectedCategory = 'muni';
+    else if (/bond|fixed income|income/.test(name.toLowerCase())) detectedCategory = 'bond';
+    else if (/international|global|world|foreign|emerging/.test(name.toLowerCase())) detectedCategory = 'intl_stock';
+    else detectedCategory = 'us_stock';
+  }
+
+  return {
+    yield: null,
+    price: null,
+    name,
+    allocation,
+    assetClass,
+    etfCategory: null,
+    detectedCategory,
+    expenseRatio: null,
+    sources: ['Dealcharts fund facts'],
+  };
+}
+
+export function inferCategoryFromTickerAndName(ticker: string, name?: string | null): CategoryKey | null {
+  const t = ticker.toUpperCase();
+  const n = (name || '').toLowerCase();
+
+  if (/money market|settlement|cash|treasury money market/.test(n)) return 'cash';
+  if (/municipal|muni|tax[- ]exempt/.test(n)) return 'muni';
+  if (/bond|fixed income|treasury|income/.test(n)) return 'bond';
+  if (/reit|real estate/.test(n)) return 'reit';
+  if (/international|foreign|emerging|ex[- ]?us|total intl|total international|global ex us/.test(n)) return 'intl_stock';
+  if (/stock|equity|index/.test(n)) return 'us_stock';
+  if (/^[A-Z]{5}X$/.test(t)) return 'us_stock';
+  return null;
+}
+
+export function hasSymbolLookupData(data: SymbolLookupResult | null | undefined): boolean {
+  if (!data) return false;
+  return Boolean(
+    data.yield != null
+      || data.price != null
+      || data.name
+      || data.allocation
+      || data.assetClass
+      || data.etfCategory
+      || data.detectedCategory
+      || data.expenseRatio != null,
+  );
+}
+
+export function isLikelyFundTicker(ticker: string, name?: string | null): boolean {
+  if (COMPOSITE_FUNDS[ticker.toUpperCase()]) return true;
+  if (/^[A-Z]{5}X$/.test(ticker.toUpperCase())) return true;
+  if (!name) return false;
+  return /\bfund\b|balanced|allocation|lifestrategy|target|income|index/i.test(name);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,18 @@ import { guessAccountType, guessCategory } from './calc/category';
 import { calculateFirePlan } from './calc/fire';
 import { renderPlannerPage } from './render/planner';
 import { estimateAccountReturn, estimateAccountYield } from './calc/account-assumptions';
+import {
+  buildDealchartsQueries,
+  emptySymbolLookupResult,
+  hasSymbolLookupData,
+  inferCategoryFromTickerAndName,
+  isLikelyFundTicker,
+  mergeSymbolLookupResults,
+  parseEodhdEodPrice,
+  parseDealchartsFundFacts,
+  parseStockAnalysisOverview,
+  pickDealchartsSearchResult,
+} from './calc/symbol-data';
 
 type AppPage = 'planner' | 'portfolio' | 'brokerages' | 'symbols' | 'drawdown' | 'conversion' | 'healthcare';
 
@@ -282,9 +294,6 @@ const APP_HTML = `
         <button class="btn" onclick="openCostBasisModal()">Import Cost Basis</button>
         <button class="btn primary" onclick="openAddModal()">+ Add Holding</button>
         <button class="btn" onclick="openTargetModal()">Set Targets</button>
-        <button class="btn" id="fetchDataBtn" onclick="handleFetchAllData()" style="white-space:nowrap;">
-          <span id="fetchDataLabel">Fetch Live Data</span>
-        </button>
       </div>
     </div>
 
@@ -321,7 +330,7 @@ const APP_HTML = `
       </div>
       <p style="font-size:0.85rem;color:var(--muted);margin-bottom:1rem;">
         Estimated annual dividends and interest by account type. The key planning number is <strong>MAGI-Relevant Investment Income</strong>, which includes taxable account income plus muni income.
-        IRA, Roth, and HSA sections are shown for context only. Click <strong>Fetch Live Data</strong> above to refresh yields and prices.
+        IRA, Roth, and HSA sections are shown for context only. Refresh symbol metadata from the <strong>Symbols</strong> tab when you want updated yields and prices.
       </p>
       <div id="investmentIncomeArea"></div>
     </div>
@@ -353,6 +362,33 @@ const APP_HTML = `
       <p style="font-size:0.85rem;color:var(--muted);margin-bottom:1rem;">
         Persisted symbol metadata, inferred asset classes, and any stored multi-asset allocation splits.
       </p>
+      <div class="planner-optional-box" style="margin-bottom:1rem;">
+        <div style="display:flex;justify-content:space-between;align-items:center;gap:0.75rem;flex-wrap:wrap;margin-bottom:0.75rem;">
+          <div>
+            <div style="font-size:0.75rem;text-transform:uppercase;font-weight:700;letter-spacing:0.06em;color:var(--muted);">Data Source</div>
+            <div style="font-size:0.92rem;">EODHD API</div>
+          </div>
+          <a href="https://eodhd.com/pricing" target="_blank" rel="noreferrer noopener" style="font-size:0.82rem;color:var(--blue);text-decoration:none;">Get API key</a>
+        </div>
+        <div class="grid-2" style="align-items:end;margin-bottom:0.5rem;">
+          <label style="display:flex;flex-direction:column;gap:0.35rem;font-size:0.8rem;color:var(--muted);">
+            <span>EODHD API Key</span>
+            <input id="symbolApiKey" class="input" type="password" placeholder="Stored locally in this browser" autocomplete="off" />
+          </label>
+          <div style="display:flex;gap:0.5rem;justify-content:flex-end;align-items:end;">
+            <button class="btn" onclick="clearSymbolApiSettings()">Clear</button>
+            <button class="btn primary" onclick="saveSymbolApiSettings()">Save API Key</button>
+          </div>
+        </div>
+        <div style="font-size:0.78rem;color:var(--muted);" id="symbolApiStatus">
+          With a key, refresh will prefer EODHD end-of-day prices, then use the public fallback sources for name, yield, expense ratio, and classification.
+        </div>
+        <div style="font-size:0.78rem;color:var(--muted);margin-top:0.5rem;line-height:1.5;">
+          1. Create an EODHD account and copy your API token from the dashboard.<br>
+          2. Paste it here and click <strong>Save API Key</strong>. The key stays in this browser only.<br>
+          3. Free EODHD access is useful for end-of-day prices. Yield and expense ratio still rely on the public fallback sources unless you add a richer fund-data provider later.
+        </div>
+      </div>
       <div id="symbolRefreshReportArea" style="margin-bottom:1rem;"></div>
       <div id="symbolCatalogArea"></div>
     </div>
@@ -753,6 +789,10 @@ type CostBasisAggregate = {
 
 const win = window as any;
 const SA_API = 'https://api.stockanalysis.com/api/symbol';
+const DEALCHARTS_SEARCH_API = 'https://dealcharts.org/.netlify/functions/search';
+const EODHD_API = 'https://eodhd.com/api';
+const SYMBOL_API_KEY_STORAGE_KEY = 'fire_eodhd_api_key';
+const SYMBOL_REFRESH_REPORT_STORAGE_KEY = 'fire_symbol_refresh_report';
 
 let csvHeaders: string[] = [];
 let csvRows: CsvRow[] = [];
@@ -786,15 +826,64 @@ let currentImportBrokerage: string | null = null;
 let tickerFetchTimer: number | null = null;
 let plannerRetireExpensesCustom = false;
 let lastAutoHouseholdSs = 20000;
-let lastRefreshReport: {
+let symbolApiKey = localStorage.getItem(SYMBOL_API_KEY_STORAGE_KEY) || '';
+type SymbolRefreshSuccess = {
+  ticker: string;
+  fields: string[];
+  sources: string[];
+};
+type SymbolRefreshFailure = {
+  ticker: string;
+  apiCalls: string[];
+  missingFields: string[];
+};
+type SymbolRefreshReport = {
   startedAt: number;
   completedAt: number;
   total: number;
   updated: number;
   failed: number;
-  successes: Array<{ ticker: string; fields: string[] }>;
-  failures: Array<{ ticker: string; error: string }>;
-} | null = null;
+  successes: SymbolRefreshSuccess[];
+  failures: SymbolRefreshFailure[];
+};
+
+function normalizeStoredRefreshReport(raw: string): SymbolRefreshReport | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return null;
+    return {
+      startedAt: Number(parsed.startedAt) || Date.now(),
+      completedAt: Number(parsed.completedAt) || Date.now(),
+      total: Number(parsed.total) || 0,
+      updated: Number(parsed.updated) || 0,
+      failed: Number(parsed.failed) || 0,
+      successes: Array.isArray(parsed.successes)
+        ? parsed.successes.map((item: any) => ({
+            ticker: String(item.ticker || ''),
+            fields: Array.isArray(item.fields) ? item.fields.map(String) : [],
+            sources: Array.isArray(item.sources) ? item.sources.map(String) : [],
+          }))
+        : [],
+      failures: Array.isArray(parsed.failures)
+        ? parsed.failures.map((item: any) => ({
+            ticker: String(item.ticker || ''),
+            apiCalls: Array.isArray(item.apiCalls)
+              ? item.apiCalls.map(String)
+              : item.error ? [String(item.error)] : [],
+            missingFields: Array.isArray(item.missingFields) ? item.missingFields.map(String) : [],
+          }))
+        : [],
+    };
+  } catch {
+    return null;
+  }
+}
+
+let lastRefreshReport: SymbolRefreshReport | null = (() => {
+  const raw = localStorage.getItem(SYMBOL_REFRESH_REPORT_STORAGE_KEY);
+  if (!raw) return null;
+  return normalizeStoredRefreshReport(raw);
+})();
 
 function syncGlobalRefs(): void {
   win.acctMap = acctMap;
@@ -884,12 +973,14 @@ function attachGlobals(): void {
     openTargetModal,
     closeTargetModal,
     saveTargets,
-    handleFetchAllData,
     handleSymbolCatalogRefresh,
     setBrokerageFilter,
     startSymbolEdit,
     cancelSymbolEdit,
     saveSymbolEdit,
+    saveSymbolApiSettings,
+    clearSymbolApiSettings,
+    clearSymbolRefreshReport,
   });
 }
 
@@ -1030,6 +1121,14 @@ function renderBrokerages(): void {
 }
 
 function renderSymbols(): void {
+  const apiKeyInput = document.getElementById('symbolApiKey') as HTMLInputElement | null;
+  if (apiKeyInput) apiKeyInput.value = symbolApiKey;
+  const apiStatus = document.getElementById('symbolApiStatus');
+  if (apiStatus) {
+    apiStatus.textContent = symbolApiKey
+      ? 'API key saved locally. Refreshes will prefer EODHD end-of-day prices before using the public fallback sources for the remaining fields.'
+      : 'Add an EODHD API key if you want end-of-day price refreshes for mutual funds. Without a key, refresh uses the public fallback sources only.';
+  }
   renderSymbolCatalogPage({ editingTicker: editingSymbolTicker });
   renderSymbolRefreshReport();
 }
@@ -1059,11 +1158,13 @@ function renderSymbolRefreshReport(): void {
         <div>
           <div style="font-size:0.75rem;text-transform:uppercase;font-weight:600;color:var(--muted);letter-spacing:0.04em;margin-bottom:0.2rem;">Last Refresh</div>
           <div style="font-size:0.9rem;">${completed}</div>
+          <div style="font-size:0.75rem;color:var(--muted);margin-top:0.2rem;">This report stays in this browser until you clear it.</div>
         </div>
-        <div style="display:flex;gap:1rem;flex-wrap:wrap;font-size:0.85rem;">
+        <div style="display:flex;gap:0.75rem;flex-wrap:wrap;font-size:0.85rem;align-items:center;">
           <span><strong>${lastRefreshReport.updated}</strong> populated</span>
-          <span><strong>${lastRefreshReport.failed}</strong> failed</span>
+          <span><strong>${lastRefreshReport.failed}</strong> with issues</span>
           <span><strong>${lastRefreshReport.total}</strong> total</span>
+          <button class="btn" style="padding:0.3rem 0.55rem;font-size:0.75rem;" onclick="clearSymbolRefreshReport()">Clear Report</button>
         </div>
       </div>
       <div class="grid-2" style="margin-bottom:0;">
@@ -1074,23 +1175,39 @@ function renderSymbolRefreshReport(): void {
                 <div style="padding:0.35rem 0;border-bottom:1px solid var(--border);">
                   <strong>${item.ticker}</strong>
                   <div style="color:var(--muted);">${item.fields.join(', ')}</div>
+                  <div style="color:var(--muted);font-size:0.76rem;">Source: ${item.sources.length > 0 ? item.sources.join(' + ') : 'Unknown'}</div>
                 </div>
               `).join('')}</div>`
             : '<div style="font-size:0.82rem;color:var(--muted);">No symbols populated.</div>'}
         </div>
         <div style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:0.9rem;">
-          <div style="font-size:0.75rem;text-transform:uppercase;font-weight:600;color:var(--muted);letter-spacing:0.04em;margin-bottom:0.5rem;">Errors</div>
+          <div style="font-size:0.75rem;text-transform:uppercase;font-weight:600;color:var(--muted);letter-spacing:0.04em;margin-bottom:0.5rem;">Issues</div>
           ${lastRefreshReport.failures.length > 0
             ? `<div style="max-height:220px;overflow:auto;font-size:0.82rem;">${lastRefreshReport.failures.map((item) => `
                 <div style="padding:0.35rem 0;border-bottom:1px solid var(--border);">
                   <strong style="color:var(--red);">${item.ticker}</strong>
-                  <div style="color:var(--muted);">${item.error}</div>
+                  <div style="color:var(--muted);font-size:0.76rem;">API calls: ${item.apiCalls.length > 0 ? item.apiCalls.join(' | ') : 'None'}</div>
+                  <div style="color:var(--muted);font-size:0.76rem;">Missing fields: ${item.missingFields.length > 0 ? item.missingFields.join(', ') : 'None'}</div>
                 </div>
               `).join('')}</div>`
-            : '<div style="font-size:0.82rem;color:var(--accent);">No symbol refresh errors.</div>'}
+            : '<div style="font-size:0.82rem;color:var(--accent);">No symbol refresh issues.</div>'}
         </div>
       </div>
     </div>`;
+}
+
+function persistSymbolRefreshReport(): void {
+  if (!lastRefreshReport) {
+    localStorage.removeItem(SYMBOL_REFRESH_REPORT_STORAGE_KEY);
+    return;
+  }
+  localStorage.setItem(SYMBOL_REFRESH_REPORT_STORAGE_KEY, JSON.stringify(lastRefreshReport));
+}
+
+function clearSymbolRefreshReport(): void {
+  lastRefreshReport = null;
+  persistSymbolRefreshReport();
+  renderSymbolRefreshReport();
 }
 
 function getHoldingBalances(): {
@@ -2498,49 +2615,151 @@ function renderDrawdownPlan(): void {
   renderLifetimePlan('dp', false);
 }
 
-async function fetchTickerData(ticker: string): Promise<{
-  yield: number;
-  price: number | null;
-  name: string | null;
-  allocation: Record<string, number> | null;
-  assetClass?: string | null;
-  etfCategory?: string | null;
-  detectedCategory?: CategoryKey | null;
-  expenseRatio?: number | null;
-} | null> {
-  const parsePercent = (value: unknown): number | null => {
-    if (value == null) return null;
-    const match = String(value).match(/([\d.]+)/);
-    return match ? parseFloat(match[1]) : null;
-  };
+function getLocalTickerDefaults(ticker: string): Partial<YieldCacheEntry> & { category?: CategoryKey } {
   const t = ticker.toUpperCase();
-  if (CASH_TICKERS.has(t)) return { yield: 4.5, price: 1, name: t, allocation: null };
-  const errors: string[] = [];
+  const cached = yieldCache[t];
+  if (cached) return cached;
+  const holding = holdings.find((item) => item.ticker.toUpperCase() === t);
+  if (!holding) return {};
+  return {
+    yield: holding.dividendYield,
+    price: holding.price,
+    name: holding.name,
+    category: holding.category,
+  };
+}
+
+function mergeFetchedTickerData(ticker: string, data: ReturnType<typeof emptySymbolLookupResult>): YieldCacheEntry {
+  const t = ticker.toUpperCase();
+  const existing = yieldCache[t];
+  const localDefaults = getLocalTickerDefaults(t);
+  return {
+    yield: data.yield ?? existing?.yield ?? localDefaults?.yield ?? 0,
+    price: data.price ?? existing?.price ?? localDefaults?.price ?? 0,
+    name: data.name || existing?.name || localDefaults?.name || t,
+    allocation: data.allocation || existing?.allocation || localDefaults?.allocation || COMPOSITE_FUNDS[t] || null,
+    assetClass: data.assetClass || existing?.assetClass,
+    etfCategory: data.etfCategory || existing?.etfCategory,
+    detectedCategory: data.detectedCategory || existing?.detectedCategory || localDefaults.category,
+    expenseRatio: data.expenseRatio ?? existing?.expenseRatio,
+    dataSource: data.sources?.length ? data.sources.join(' + ') : existing?.dataSource,
+    fetched: Date.now(),
+  };
+}
+
+function getExpectedRefreshFields(ticker: string, name?: string | null): string[] {
+  const expected = ['name', 'price', 'yield'];
+  if (isLikelyFundTicker(ticker, name || null)) {
+    expected.push('expense ratio');
+    expected.push('classification');
+  }
+  return expected;
+}
+
+function getPresentRefreshFields(data: ReturnType<typeof emptySymbolLookupResult>): string[] {
+  const present: string[] = [];
+  if (data.name) present.push('name');
+  if (data.price != null && data.price > 0) present.push('price');
+  if (data.yield != null) present.push('yield');
+  if (data.expenseRatio != null) present.push('expense ratio');
+  if (data.allocation || data.assetClass || data.detectedCategory) present.push('classification');
+  return present;
+}
+
+async function formatHttpFailure(resp: Response, label: string): Promise<string> {
+  let detail = '';
+  try {
+    const text = (await resp.text()).trim();
+    if (text) {
+      const compact = text.replace(/\s+/g, ' ').slice(0, 180);
+      detail = `: ${compact}`;
+    }
+  } catch {
+    detail = '';
+  }
+  return `${label} (HTTP ${resp.status})${detail}`;
+}
+
+function formatIsoDate(daysAgo: number): string {
+  const date = new Date();
+  date.setDate(date.getDate() - daysAgo);
+  return date.toISOString().slice(0, 10);
+}
+
+async function fetchTickerData(
+  ticker: string,
+): Promise<{
+  data: ReturnType<typeof emptySymbolLookupResult> | null;
+  apiCalls: string[];
+  missingFields: string[];
+}> {
+  const t = ticker.toUpperCase();
+  if (CASH_TICKERS.has(t)) {
+    const data = {
+      yield: 4.5,
+      price: 1,
+      name: t,
+      allocation: null,
+      assetClass: null,
+      etfCategory: null,
+      detectedCategory: null,
+      expenseRatio: null,
+      sources: ['Built-in cash defaults'],
+    };
+    return { data, apiCalls: [], missingFields: [] };
+  }
+
+  const localDefaults = getLocalTickerDefaults(t);
+  const likelyFund = isLikelyFundTicker(t, localDefaults.name || null);
+  let merged = mergeSymbolLookupResults(emptySymbolLookupResult(), {
+    yield: null,
+    price: null,
+    name: localDefaults?.name || null,
+    allocation: COMPOSITE_FUNDS[t] || null,
+    assetClass: null,
+    etfCategory: null,
+    detectedCategory: localDefaults.category || null,
+    expenseRatio: localDefaults.expenseRatio ?? null,
+  });
+  const apiCalls: string[] = [];
+
+  if (symbolApiKey) {
+    try {
+      const eodResp = await fetch(
+        `${EODHD_API}/eod/${encodeURIComponent(`${t}.US`)}?api_token=${encodeURIComponent(symbolApiKey)}&fmt=json&from=${formatIsoDate(14)}`,
+      );
+      if (!eodResp.ok) {
+        apiCalls.push(await formatHttpFailure(
+          eodResp,
+          eodResp.status === 402 || eodResp.status === 403 || eodResp.status === 429
+            ? 'EODHD end-of-day price blocked by plan/quota'
+            : 'EODHD end-of-day price',
+        ));
+      } else {
+        const eodJson = await eodResp.json();
+        merged = mergeSymbolLookupResults(merged, parseEodhdEodPrice(eodJson));
+      }
+    } catch (error) {
+      apiCalls.push(`EODHD end-of-day price error: ${(error as Error).message}`);
+    }
+  }
 
   for (const type of ['e', 's']) {
     try {
       const resp = await fetch(`${SA_API}/${type}/${t}/overview`);
       if (!resp.ok) {
-        errors.push(`${type}/overview returned HTTP ${resp.status}`);
+        apiCalls.push(await formatHttpFailure(resp, `Stock Analysis ${type}/overview`));
         continue;
       }
       const json = await resp.json();
       const d = json.data;
       if (!d) {
-        errors.push(`${type}/overview returned no data`);
+        apiCalls.push(`Stock Analysis ${type}/overview returned no data`);
         continue;
       }
 
-      let yld: number | null = null;
-      if (d.dividendYield) yld = parseFloat(d.dividendYield);
-      else if (d.dividend) {
-        const match = String(d.dividend).match(/([\d.]+)%/);
-        if (match) yld = parseFloat(match[1]);
-      }
-
-      let price: number | null = null;
-      if (d.nav) price = parseFloat(String(d.nav).replace(/[$,]/g, ''));
-      else if (d.price) price = parseFloat(String(d.price).replace(/[$,]/g, ''));
+      const parsed = parseStockAnalysisOverview(t, d);
+      let price = parsed?.price ?? null;
 
       if (price === null && type === 's') {
         try {
@@ -2551,92 +2770,78 @@ async function fetchTickerData(ticker: string): Promise<{
               price = historyJson.data[0].c;
             }
           } else {
-            errors.push(`${type}/history returned HTTP ${historyResp.status}`);
+            apiCalls.push(await formatHttpFailure(historyResp, `Stock Analysis ${type}/history`));
           }
         } catch (error) {
-          errors.push(`${type}/history error: ${(error as Error).message}`);
+          apiCalls.push(`Stock Analysis ${type}/history error: ${(error as Error).message}`);
         }
       }
-
-      let name: string | null = null;
-      if (d.name) name = d.name;
-      else if (d.description) {
-        const firstSentence = String(d.description).split(/\.\s/)[0];
-        const nameMatch = firstSentence.match(/^(.+?)(?:\s+is\s|\s+designs\s|\s+provides\s|\s+develops\s|\s+operates\s|\s+manufactures\s)/i);
-        name = nameMatch ? nameMatch[1] : firstSentence.substring(0, 50);
-      }
-
-      let assetClass: string | null = null;
-      let etfCategory: string | null = null;
-      let expenseRatio: number | null = parsePercent((d as any).expenseRatio ?? (d as any).expense_ratio ?? (d as any).netExpenseRatio ?? (d as any).net_expense_ratio);
-      const infoTable = d.infoTable;
-      if (Array.isArray(infoTable)) {
-        for (const item of infoTable) {
-          if (Array.isArray(item)) {
-            const label = String(item[0] || '');
-            const normalizedLabel = label.toLowerCase();
-            if (label === 'Asset Class') assetClass = item[1];
-            if (label === 'Category') etfCategory = item[1];
-            if (item[1] && normalizedLabel.includes('expense') && normalizedLabel.includes('ratio')) {
-              expenseRatio = parsePercent(item[1]) ?? expenseRatio;
-            }
-          }
-        }
-      }
-
-      let allocation: Record<string, number> | null = COMPOSITE_FUNDS[t] || null;
-      if (!allocation && assetClass === 'Asset Allocation' && etfCategory) {
-        const cat = etfCategory.toLowerCase();
-        if (cat.includes('aggressive') || cat.includes('85') || cat.includes('80')) allocation = { us_stock: 0.48, intl_stock: 0.32, bond: 0.16, cash: 0.04 };
-        else if (cat.includes('growth') || cat.includes('60')) allocation = { us_stock: 0.36, intl_stock: 0.24, bond: 0.32, cash: 0.08 };
-        else if (cat.includes('moderate') || cat.includes('50') || cat.includes('balanced')) allocation = { us_stock: 0.30, intl_stock: 0.20, bond: 0.35, cash: 0.15 };
-        else if (cat.includes('conservative') || cat.includes('30') || cat.includes('40')) allocation = { us_stock: 0.24, intl_stock: 0.16, bond: 0.42, cash: 0.18 };
-        else if (cat.includes('income') || cat.includes('20')) allocation = { us_stock: 0.12, intl_stock: 0.08, bond: 0.56, cash: 0.24 };
-      }
-
-      let detectedCategory: CategoryKey | null = null;
-      if (assetClass === 'Fixed Income') detectedCategory = 'bond';
-      else if (assetClass === 'Equity') {
-        detectedCategory = etfCategory && /international|foreign|emerging|global/i.test(etfCategory)
-          ? 'intl_stock'
-          : 'us_stock';
-      } else if (assetClass === 'Real Estate') {
-        detectedCategory = 'reit';
-      }
-
-      return {
-        yield: yld ?? 0,
-        price,
-        name,
-        allocation,
-        assetClass,
-        etfCategory,
-        detectedCategory,
-        expenseRatio,
-      };
+      merged = mergeSymbolLookupResults(merged, parsed, { ...parsed, price, sources: price != null && parsed?.price == null ? ['Stock Analysis history'] : parsed?.sources || [] });
     } catch (error) {
-      errors.push(`${type}/overview error: ${(error as Error).message}`);
+      apiCalls.push(`Stock Analysis ${type}/overview error: ${(error as Error).message}`);
       continue;
     }
   }
 
-  throw new Error(errors.join('; ') || 'No symbol data returned');
+  if (!merged.allocation && isLikelyFundTicker(t, merged.name || localDefaults?.name || null)) {
+    const queries = buildDealchartsQueries(t, merged.name || localDefaults?.name || null);
+    for (const query of queries) {
+      try {
+        const searchResp = await fetch(`${DEALCHARTS_SEARCH_API}?query=${encodeURIComponent(query)}`);
+        if (!searchResp.ok) {
+          apiCalls.push(await formatHttpFailure(searchResp, `Dealcharts search "${query}"`));
+          continue;
+        }
+        const searchJson = await searchResp.json();
+        const result = pickDealchartsSearchResult(Array.isArray(searchJson) ? searchJson : [], t, merged.name || localDefaults?.name || null);
+        if (!result?.facts_url) continue;
+
+        const factsResp = await fetch(result.facts_url);
+        if (!factsResp.ok) {
+          apiCalls.push(await formatHttpFailure(factsResp, `Dealcharts facts "${query}"`));
+          continue;
+        }
+        const factsJson = await factsResp.json();
+        merged = mergeSymbolLookupResults(merged, parseDealchartsFundFacts(t, factsJson));
+        if (merged.allocation || merged.name) break;
+      } catch (error) {
+        apiCalls.push(`Dealcharts lookup "${query}" error: ${(error as Error).message}`);
+      }
+    }
+  }
+
+  if (symbolApiKey && likelyFund && (merged.expenseRatio == null || merged.yield == null)) {
+    apiCalls.push('EODHD free-key flow only requested end-of-day price; yield and expense ratio still depend on the public fallback sources');
+  }
+
+  if (!merged.detectedCategory) {
+    const inferredCategory = inferCategoryFromTickerAndName(t, merged.name || localDefaults.name || null);
+    if (inferredCategory) {
+      merged = mergeSymbolLookupResults(merged, {
+        yield: null,
+        price: null,
+        name: null,
+        allocation: null,
+        assetClass: null,
+        etfCategory: null,
+        detectedCategory: inferredCategory,
+        expenseRatio: null,
+        sources: ['Name-based classification fallback'],
+      });
+    }
+  }
+
+  const missingFields = getExpectedRefreshFields(t, merged.name || localDefaults.name || null)
+    .filter((field) => !getPresentRefreshFields(merged).includes(field));
+
+  if (hasSymbolLookupData(merged)) return { data: merged, apiCalls, missingFields };
+  return { data: null, apiCalls, missingFields };
 }
 
 async function fetchSingleYield(ticker: string) {
-  const data = await fetchTickerData(ticker);
+  const { data } = await fetchTickerData(ticker);
   if (data) {
-    yieldCache[ticker.toUpperCase()] = {
-      yield: data.yield,
-      price: data.price || 0,
-      name: data.name || ticker.toUpperCase(),
-      allocation: data.allocation || null,
-      assetClass: data.assetClass || undefined,
-      etfCategory: data.etfCategory || undefined,
-      detectedCategory: data.detectedCategory || undefined,
-      expenseRatio: data.expenseRatio || undefined,
-      fetched: Date.now(),
-    };
+    yieldCache[ticker.toUpperCase()] = mergeFetchedTickerData(ticker, data);
     persistYieldCache();
   }
   return data;
@@ -2646,22 +2851,23 @@ async function fetchAllYields(statusEl?: HTMLElement | null): Promise<{
   total: number;
   updated: number;
   failed: number;
-  successes: Array<{ ticker: string; fields: string[] }>;
-  failures: Array<{ ticker: string; error: string }>;
+  successes: SymbolRefreshSuccess[];
+  failures: SymbolRefreshFailure[];
 }> {
   const tickers = [...new Set(holdings.map((h) => h.ticker.toUpperCase()))];
   let done = 0;
   let updated = 0;
   let failed = 0;
-  const successes: Array<{ ticker: string; fields: string[] }> = [];
-  const failures: Array<{ ticker: string; error: string }> = [];
+  const successes: SymbolRefreshSuccess[] = [];
+  const failures: SymbolRefreshFailure[] = [];
 
   for (const ticker of tickers) {
     if (statusEl) statusEl.textContent = `Fetching ${ticker}... (${done}/${tickers.length})`;
 
-    try {
-      const data = await fetchTickerData(ticker);
-      if (data) {
+    const result = await fetchTickerData(ticker);
+    const apiCalls = result.apiCalls;
+    const data = result.data;
+    if (data) {
         const fields: string[] = [];
         if (data.yield != null) fields.push('yield');
         if (data.price != null && data.price > 0) fields.push('price');
@@ -2670,35 +2876,32 @@ async function fetchAllYields(statusEl?: HTMLElement | null): Promise<{
         if (data.detectedCategory) fields.push('category');
         if (data.allocation) fields.push('allocation split');
         if (data.expenseRatio != null) fields.push('expense ratio');
-        yieldCache[ticker] = {
-          yield: data.yield,
-          price: data.price || 0,
-          name: data.name || ticker,
-          allocation: data.allocation || null,
-          assetClass: data.assetClass || undefined,
-          etfCategory: data.etfCategory || undefined,
-          detectedCategory: data.detectedCategory || undefined,
-          expenseRatio: data.expenseRatio || undefined,
-          fetched: Date.now(),
-        };
+        yieldCache[ticker] = mergeFetchedTickerData(ticker, data);
 
         for (const h of holdings) {
           if (h.ticker.toUpperCase() === ticker) {
-            h.dividendYield = data.yield;
+            if (data.yield != null) h.dividendYield = data.yield;
             if (data.price && data.price > 0) h.price = Math.round(data.price * 100) / 100;
             if (data.name && data.name.length > 2 && h.name === h.ticker) h.name = data.name;
             if (data.detectedCategory && !data.allocation) h.category = data.detectedCategory;
           }
         }
         updated++;
-        successes.push({ ticker, fields: fields.length > 0 ? fields : ['no new fields detected'] });
-      } else {
-        failed++;
-        failures.push({ ticker, error: 'No data returned from the symbol data source.' });
-      }
-    } catch (error) {
+        successes.push({
+          ticker,
+          fields: fields.length > 0 ? fields : ['no new fields detected'],
+          sources: data.sources || [],
+        });
+    }
+
+    const hasIssues = !data || apiCalls.length > 0 || result.missingFields.length > 0;
+    if (hasIssues) {
       failed++;
-      failures.push({ ticker, error: (error as Error).message || 'Unknown refresh error' });
+      failures.push({
+        ticker,
+        apiCalls: apiCalls.length > 0 ? apiCalls : ['No symbol data returned'],
+        missingFields: result.missingFields,
+      });
     }
 
     done++;
@@ -2730,6 +2933,7 @@ async function runDataRefresh(buttonId: string, labelId: string, idleLabel: stri
       completedAt: Date.now(),
       ...result,
     };
+    persistSymbolRefreshReport();
     renderSymbolRefreshReport();
     label.textContent = idleLabel;
     showImportToast(`${result.updated} populated${result.failed > 0 ? `, ${result.failed} failed` : ''} — symbol data refreshed`);
@@ -2741,8 +2945,9 @@ async function runDataRefresh(buttonId: string, labelId: string, idleLabel: stri
       updated: 0,
       failed: 1,
       successes: [],
-      failures: [{ ticker: 'ALL', error: (error as Error).message }],
+      failures: [{ ticker: 'ALL', apiCalls: [(error as Error).message], missingFields: [] }],
     };
+    persistSymbolRefreshReport();
     renderSymbolRefreshReport();
     label.textContent = idleLabel;
     showImportToast(`Fetch failed: ${(error as Error).message}`);
@@ -2750,6 +2955,21 @@ async function runDataRefresh(buttonId: string, labelId: string, idleLabel: stri
     btn.disabled = false;
     btn.style.opacity = '';
   }
+}
+
+function saveSymbolApiSettings(): void {
+  const input = $('symbolApiKey') as HTMLInputElement;
+  symbolApiKey = input.value.trim();
+  localStorage.setItem(SYMBOL_API_KEY_STORAGE_KEY, symbolApiKey);
+  renderSymbols();
+  showImportToast(symbolApiKey ? 'Saved EODHD API key locally' : 'Removed EODHD API key');
+}
+
+function clearSymbolApiSettings(): void {
+  symbolApiKey = '';
+  localStorage.removeItem(SYMBOL_API_KEY_STORAGE_KEY);
+  renderSymbols();
+  showImportToast('Cleared EODHD API key');
 }
 
 function parseSymbolAllocationInput(value: string): Record<string, number> | null {
@@ -2822,6 +3042,7 @@ function getSymbolCacheEntry(ticker: string): YieldCacheEntry {
     name: holding?.name || upper,
     allocation: null,
     detectedCategory: holding?.category,
+    dataSource: 'Manual',
     fetched: 0,
   };
   yieldCache[upper] = created;
@@ -2866,6 +3087,7 @@ function saveSymbolEdit(ticker: string): void {
     entry.allocation = allocation;
     entry.yield = parsedYield;
     entry.expenseRatio = parsedExpense ?? undefined;
+    entry.dataSource = 'Manual edit';
     yieldCache[upper] = entry;
 
     for (const holding of holdings) {
@@ -2883,10 +3105,6 @@ function saveSymbolEdit(ticker: string): void {
   } catch (error) {
     alert(`Failed to save symbol metadata: ${(error as Error).message}`);
   }
-}
-
-async function handleFetchAllData(): Promise<void> {
-  await runDataRefresh('fetchDataBtn', 'fetchDataLabel', 'Fetch Live Data');
 }
 
 async function handleSymbolCatalogRefresh(): Promise<void> {
@@ -3718,6 +3936,7 @@ function loadDemoPortfolio(event: Event): void {
   activeBrokerageFilter = 'all';
   editingSymbolTicker = null;
   lastRefreshReport = null;
+  persistSymbolRefreshReport();
   resetCsvState();
   cbParsedRows = [];
   const plannerDefaults: Record<(typeof plannerInputIds)[number], string> = {

--- a/src/render/investment-income.ts
+++ b/src/render/investment-income.ts
@@ -38,7 +38,7 @@ export function renderInvestmentIncome(): void {
     );
     $('yieldFreshness').style.color = days > 7 ? 'var(--red)' : days > 1 ? 'var(--orange)' : 'var(--accent)';
   } else {
-    $('yieldFreshness').textContent = 'Using estimates \u2014 click Fetch Live Data';
+    $('yieldFreshness').textContent = 'Using estimates \u2014 refresh from Symbols';
     $('yieldFreshness').style.color = 'var(--muted)';
   }
 

--- a/src/render/symbol-catalog.ts
+++ b/src/render/symbol-catalog.ts
@@ -13,6 +13,7 @@ interface SymbolRow {
   assetClass: string;
   yield: number;
   expenseRatio: number | null;
+  dataSource: string | null;
   brokerages: string[];
   holdingsCount: number;
   fetched: number;
@@ -84,6 +85,7 @@ function getSymbolRows(): SymbolRow[] {
       assetClass: cache?.assetClass || (category ? CATEGORIES[category]?.label || category : 'Unknown'),
       yield: cache?.yield ?? firstHolding?.dividendYield ?? 0,
       expenseRatio: cache?.expenseRatio ?? null,
+      dataSource: cache?.dataSource ?? null,
       brokerages: [...new Set(symbolHoldings.map((holding) => getBrokerageName(holding.brokerage)))].sort((a, b) => a.localeCompare(b)),
       holdingsCount: symbolHoldings.length,
       fetched: cache?.fetched ?? 0,
@@ -142,6 +144,7 @@ export function renderSymbolCatalogPage(options: SymbolCatalogRenderOptions = {}
               <a href="${getYahooFinanceUrl(row.ticker)}" target="_blank" rel="noreferrer noopener" style="color:var(--blue);text-decoration:none;">
                 ${esc(row.name)}
               </a>
+              ${row.dataSource ? `<div style="font-size:0.72rem;color:var(--muted);margin-top:0.15rem;">Source: ${esc(row.dataSource)}</div>` : ''}
             </td>
             <td style="min-width:280px;white-space:normal;line-height:1.4;">${describeAssetClass(row.assetClass, row.allocation, row.category)}</td>
             <td>${fmtD(row.yield, 1)}%</td>

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -85,6 +85,7 @@ function backfillYieldCacheFromHoldings(): void {
       etfCategory: existing?.etfCategory,
       detectedCategory: existing?.detectedCategory ?? holding.category,
       expenseRatio: existing?.expenseRatio,
+      dataSource: existing?.dataSource,
       fetched: existing?.fetched ?? 0,
     };
   }
@@ -154,6 +155,7 @@ export function createDemoYieldCache(): YieldCache {
       allocation: COMPOSITE_FUNDS[ticker] ?? null,
       detectedCategory: holding.category,
       expenseRatio: DEMO_EXPENSE_RATIOS[ticker],
+      dataSource: 'Demo seed',
       fetched: 0,
     };
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -183,6 +183,7 @@ export interface YieldCacheEntry {
   etfCategory?: string;
   detectedCategory?: CategoryKey;
   expenseRatio?: number;
+  dataSource?: string;
   fetched: number;
 }
 

--- a/tests/calc/symbol-data.test.ts
+++ b/tests/calc/symbol-data.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildDealchartsQueries,
+  hasSymbolLookupData,
+  parseEodhdEodPrice,
+  parseDealchartsFundFacts,
+  parseStockAnalysisOverview,
+  pickDealchartsSearchResult,
+} from '../../src/calc/symbol-data';
+
+describe('parseStockAnalysisOverview', () => {
+  it('infers balanced-fund allocation from asset allocation labels', () => {
+    const parsed = parseStockAnalysisOverview('TESTX', {
+      name: 'Balanced Test Fund',
+      dividendYield: '2.1',
+      nav: '$15.25',
+      infoTable: [
+        ['Asset Class', 'Asset Allocation'],
+        ['Category', 'Moderate Allocation'],
+        ['Net Expense Ratio', '0.18%'],
+      ],
+    });
+
+    expect(parsed).not.toBeNull();
+    expect(parsed?.yield).toBe(2.1);
+    expect(parsed?.price).toBe(15.25);
+    expect(parsed?.expenseRatio).toBe(0.18);
+    expect(parsed?.allocation).toEqual({
+      us_stock: 0.30,
+      intl_stock: 0.20,
+      bond: 0.35,
+      cash: 0.15,
+    });
+  });
+});
+
+describe('Dealcharts helpers', () => {
+  it('builds useful search queries for mutual funds', () => {
+    expect(buildDealchartsQueries('VTMFX', 'Vanguard Tax-Managed Balanced')).toEqual([
+      'VTMFX',
+      'Vanguard Tax-Managed Balanced',
+      'Vanguard Tax-Managed Balanced fund',
+    ]);
+  });
+
+  it('picks the best matching search result', () => {
+    const result = pickDealchartsSearchResult([
+      { key: 'random-fund', nameLong: 'Random Income Fund', facts_url: 'https://example.com/a.json' },
+      { key: 'vanguard-tax-managed-balanced-fund', nameLong: 'VANGUARD TAX-MANAGED BALANCED FUND', facts_url: 'https://example.com/b.json' },
+    ], 'VTMFX', 'Vanguard Tax-Managed Balanced');
+
+    expect(result?.facts_url).toBe('https://example.com/b.json');
+  });
+
+  it('derives a blended mutual-fund allocation from holdings facts', () => {
+    const parsed = parseDealchartsFundFacts('ABCDX', {
+      name: 'Balanced Municipal Fund',
+      holdings: [
+        { asset_cat: 'EC', inv_country: 'US', value_usd: 500 },
+        { asset_cat: 'DBT', issuer_cat: 'MUNI', value_usd: 500 },
+      ],
+    });
+
+    expect(parsed?.allocation).toEqual({
+      us_stock: 0.5,
+      muni: 0.5,
+    });
+    expect(parsed?.name).toBe('Balanced Municipal Fund');
+    expect(hasSymbolLookupData(parsed)).toBe(true);
+  });
+
+  it('falls back to asset-category summary when holdings are absent', () => {
+    const parsed = parseDealchartsFundFacts('WORLDX', {
+      name: 'Global Allocation Fund',
+      summary: {
+        total_value_usd: 1000,
+        by_asset_category: {
+          EC: { total_value_usd: 600 },
+          DBT: { total_value_usd: 400 },
+        },
+      },
+    });
+
+    expect(parsed?.allocation).toEqual({
+      intl_stock: 0.6,
+      bond: 0.4,
+    });
+  });
+});
+
+describe('EODHD helpers', () => {
+  it('parses end-of-day payloads', () => {
+    const parsed = parseEodhdEodPrice([
+      { date: '2026-03-18', adjusted_close: '49.85' },
+      { date: '2026-03-19', adjusted_close: '50.12' },
+    ]);
+
+    expect(parsed?.price).toBe(50.12);
+    expect(parsed?.sources).toEqual(['EODHD end-of-day price']);
+  });
+});


### PR DESCRIPTION
## Summary
- move symbol refresh management into the Symbols page with persisted refresh reports and local EODHD API key support
- add multi-source symbol lookup helpers, data source tracking, and symbol catalog source visibility
- cover the new symbol parsing logic with unit tests and include the local 2026 planning backlog doc

## Testing
- npm test
- npm run build

Closes #12