### PR TITLE
Rebalance lifetime simulation yearly

### DIFF
--- a/src/calc/rebalance.ts
+++ b/src/calc/rebalance.ts
@@ -1,0 +1,178 @@
+import type { AccountType, CategoryKey, Holding, YieldCache } from '../types';
+import { CATEGORY_TOTAL_RETURNS } from '../constants/returns';
+import { TAX_LOCATION_RULES } from '../constants/tax';
+import { CATEGORY_YIELDS } from '../constants/yields';
+import { getEffectiveAllocation } from './allocation';
+
+export type RebalanceAccount = 'taxable' | 'ira' | 'roth';
+export type AccountCategoryBalances = Record<RebalanceAccount, Record<CategoryKey, number>>;
+
+const CATEGORY_KEYS: CategoryKey[] = ['us_stock', 'intl_stock', 'bond', 'muni', 'reit', 'cash', 'crypto', 'other'];
+const INVESTED_CATEGORY_KEYS: CategoryKey[] = CATEGORY_KEYS.filter((category) => category !== 'cash');
+const REBALANCE_ACCOUNTS: RebalanceAccount[] = ['taxable', 'ira', 'roth'];
+
+function emptyCategoryBalances(): Record<CategoryKey, number> {
+  return {
+    us_stock: 0,
+    intl_stock: 0,
+    bond: 0,
+    muni: 0,
+    reit: 0,
+    cash: 0,
+    crypto: 0,
+    other: 0,
+  };
+}
+
+export function createEmptyAccountCategoryBalances(): AccountCategoryBalances {
+  return {
+    taxable: emptyCategoryBalances(),
+    ira: emptyCategoryBalances(),
+    roth: emptyCategoryBalances(),
+  };
+}
+
+function normalizeAccount(account: AccountType): RebalanceAccount {
+  return account === 'hsa' ? 'roth' : account;
+}
+
+function getPreferredAccounts(category: CategoryKey): RebalanceAccount[] {
+  const preferred = TAX_LOCATION_RULES[category]?.ideal || ['taxable', 'ira', 'roth'];
+  const seen = new Set<RebalanceAccount>();
+  const normalized: RebalanceAccount[] = [];
+  for (const account of preferred) {
+    const next = normalizeAccount(account);
+    if (!seen.has(next)) {
+      normalized.push(next);
+      seen.add(next);
+    }
+  }
+  for (const account of REBALANCE_ACCOUNTS) {
+    if (!seen.has(account)) normalized.push(account);
+  }
+  return normalized;
+}
+
+export function getAccountBalance(
+  accountBalances: AccountCategoryBalances,
+  account: RebalanceAccount,
+): number {
+  return CATEGORY_KEYS.reduce((sum, category) => sum + accountBalances[account][category], 0);
+}
+
+export function deriveInvestedTargetMix(
+  holdings: Holding[],
+  yieldCache?: YieldCache,
+): Record<CategoryKey, number> {
+  const byCategory = emptyCategoryBalances();
+  let totalInvested = 0;
+
+  for (const holding of holdings) {
+    const allocation = getEffectiveAllocation(holding, yieldCache);
+    for (const [rawCategory, amount] of Object.entries(allocation) as Array<[CategoryKey, number]>) {
+      if (rawCategory === 'cash' || amount <= 0) continue;
+      byCategory[rawCategory] += amount;
+      totalInvested += amount;
+    }
+  }
+
+  if (totalInvested <= 0) return byCategory;
+
+  for (const category of INVESTED_CATEGORY_KEYS) {
+    byCategory[category] /= totalInvested;
+  }
+  byCategory.cash = 0;
+  return byCategory;
+}
+
+export function rebalanceInvestedAccounts(
+  accountTotals: Record<RebalanceAccount, number>,
+  targetWeights: Record<CategoryKey, number>,
+): AccountCategoryBalances {
+  const rebalanced = createEmptyAccountCategoryBalances();
+  const remainingCapacity: Record<RebalanceAccount, number> = {
+    taxable: Math.max(accountTotals.taxable || 0, 0),
+    ira: Math.max(accountTotals.ira || 0, 0),
+    roth: Math.max(accountTotals.roth || 0, 0),
+  };
+  const totalInvested = remainingCapacity.taxable + remainingCapacity.ira + remainingCapacity.roth;
+  if (totalInvested <= 0) return rebalanced;
+
+  const categories = INVESTED_CATEGORY_KEYS
+    .map((category) => ({
+      category,
+      amount: totalInvested * Math.max(targetWeights[category] || 0, 0),
+      preferredAccounts: getPreferredAccounts(category),
+    }))
+    .filter((item) => item.amount > 0)
+    .sort((left, right) => {
+      const prefDiff = left.preferredAccounts.length - right.preferredAccounts.length;
+      if (prefDiff !== 0) return prefDiff;
+      return right.amount - left.amount;
+    });
+
+  for (const item of categories) {
+    let remaining = item.amount;
+    for (const account of item.preferredAccounts) {
+      if (remaining <= 0) break;
+      const allocation = Math.min(remaining, remainingCapacity[account]);
+      if (allocation <= 0) continue;
+      rebalanced[account][item.category] += allocation;
+      remainingCapacity[account] -= allocation;
+      remaining -= allocation;
+    }
+  }
+
+  const residualCapacity = REBALANCE_ACCOUNTS.reduce((sum, account) => sum + remainingCapacity[account], 0);
+  if (residualCapacity > 0.01) {
+    const fallbackCategory = categories[0]?.category || 'other';
+    for (const account of REBALANCE_ACCOUNTS) {
+      if (remainingCapacity[account] <= 0) continue;
+      rebalanced[account][fallbackCategory] += remainingCapacity[account];
+      remainingCapacity[account] = 0;
+    }
+  }
+
+  return rebalanced;
+}
+
+export function estimateAccountReturnFromBalances(
+  accountBalances: AccountCategoryBalances,
+  account: RebalanceAccount,
+): number {
+  const total = getAccountBalance(accountBalances, account);
+  if (total <= 0) return 0;
+
+  return CATEGORY_KEYS.reduce((sum, category) => {
+    const amount = accountBalances[account][category];
+    if (amount <= 0) return sum;
+    return sum + amount * (CATEGORY_TOTAL_RETURNS[category] || CATEGORY_TOTAL_RETURNS.other);
+  }, 0) / total;
+}
+
+export function estimateAccountYieldFromBalances(
+  accountBalances: AccountCategoryBalances,
+  account: RebalanceAccount,
+): number {
+  const total = getAccountBalance(accountBalances, account);
+  if (total <= 0) return 0;
+
+  return CATEGORY_KEYS.reduce((sum, category) => {
+    const amount = accountBalances[account][category];
+    if (amount <= 0) return sum;
+    return sum + amount * (CATEGORY_YIELDS[category] || CATEGORY_YIELDS.other);
+  }, 0) / total;
+}
+
+export function growRebalancedAccounts(
+  accountBalances: AccountCategoryBalances,
+): AccountCategoryBalances {
+  const grown = createEmptyAccountCategoryBalances();
+  for (const account of REBALANCE_ACCOUNTS) {
+    for (const category of CATEGORY_KEYS) {
+      const amount = accountBalances[account][category];
+      grown[account][category] = amount * (1 + ((CATEGORY_TOTAL_RETURNS[category] || CATEGORY_TOTAL_RETURNS.other) / 100));
+    }
+  }
+  return grown;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -44,11 +44,18 @@ import { ACA_FPL_ADDITIONAL_PERSON_BASELINE, ACA_FPL_BASELINE, ACA_PLANNING_BASE
 import { IRMAA_BRACKETS, MEDICARE_PLANNING_BASELINE_LABEL } from './constants/medicare';
 import { PLANNING_GROWTH_RATES } from './constants/planning';
 import { TAX_PLANNING_BASELINE_LABEL } from './constants/tax';
+import { CATEGORY_TOTAL_RETURNS } from './constants/returns';
 import { simulateDrawdown, getRmdFactor } from './calc/drawdown';
 import { guessAccountType, guessCategory } from './calc/category';
 import { calculateFirePlan } from './calc/fire';
 import { renderPlannerPage } from './render/planner';
-import { estimateAccountReturn, estimateAccountYield, estimateHoldingsReturn } from './calc/account-assumptions';
+import { estimateAccountReturn, estimateAccountYield } from './calc/account-assumptions';
+import {
+  deriveInvestedTargetMix,
+  estimateAccountReturnFromBalances,
+  estimateAccountYieldFromBalances,
+  rebalanceInvestedAccounts,
+} from './calc/rebalance';
 import {
   buildDealchartsQueries,
   emptySymbolLookupResult,
@@ -1859,36 +1866,36 @@ function renderLifetimePlan(prefix: 'co' | 'dp', allowConversion: boolean): void
   const strategy = allowConversion ? $(`${prefix}Strategy`).value : 'none';
   const convEndAge = 72;
   const taxableCashHoldings = holdings.filter((holding) => holding.account === 'taxable' && holding.category === 'cash');
-  const taxableInvestedHoldings = holdings.filter((holding) => holding.account === 'taxable' && holding.category !== 'cash');
-  const investedHoldings = holdings.filter((holding) => holding.category !== 'cash');
-  const estimatedInvestedGrowthPct = investedHoldings.length > 0
-    ? estimateHoldingsReturn(investedHoldings, yieldCache)
-    : 0;
+  const investedTargetMix = deriveInvestedTargetMix(holdings, yieldCache);
+  const estimatedRebalancedMix = rebalanceInvestedAccounts(
+    {
+      taxable: taxableInvestedBal,
+      ira: iraBalance,
+      roth: rothBal,
+    },
+    investedTargetMix,
+  );
+  const estimatedTaxableGrowthPct = estimateAccountReturnFromBalances(estimatedRebalancedMix, 'taxable');
+  const estimatedIraGrowthPct = estimateAccountReturnFromBalances(estimatedRebalancedMix, 'ira');
+  const estimatedRothGrowthPct = estimateAccountReturnFromBalances(estimatedRebalancedMix, 'roth');
   const estimatedTaxableCashGrowthPct = taxableCashHoldings.length > 0
     ? estimateAccountReturn(taxableCashHoldings, ['taxable'], yieldCache)
-    : estimatedInvestedGrowthPct;
+    : CATEGORY_TOTAL_RETURNS.cash;
   const taxableReturnOverride = $(`${prefix}TaxableReturn`).value.trim();
   const iraReturnOverride = $(`${prefix}IraReturn`).value.trim();
   const rothReturnOverride = $(`${prefix}RothReturn`).value.trim();
-  const taxableGrowthPct = readFloat(`${prefix}TaxableReturn`, estimatedInvestedGrowthPct);
-  const iraGrowthPct = readFloat(`${prefix}IraReturn`, estimatedInvestedGrowthPct);
-  const rothGrowthPct = readFloat(`${prefix}RothReturn`, estimatedInvestedGrowthPct);
+  const taxableGrowthPct = readFloat(`${prefix}TaxableReturn`, estimatedTaxableGrowthPct);
+  const iraGrowthPct = readFloat(`${prefix}IraReturn`, estimatedIraGrowthPct);
+  const rothGrowthPct = readFloat(`${prefix}RothReturn`, estimatedRothGrowthPct);
   const taxableCashGrowthPct = taxableReturnOverride ? taxableGrowthPct : estimatedTaxableCashGrowthPct;
-  const taxableInvestedGrowthPct = taxableReturnOverride ? taxableGrowthPct : estimatedInvestedGrowthPct;
   const taxableCashGrowth = taxableCashGrowthPct / 100;
-  const taxableInvestedGrowth = taxableInvestedGrowthPct / 100;
-  const iraGrowth = iraGrowthPct / 100;
-  const rothGrowth = rothGrowthPct / 100;
   const taxableCashYield = taxableCashHoldings.length > 0
     ? estimateAccountYield(taxableCashHoldings, ['taxable'], getHoldingYield) / 100
     : 0;
-  const taxableInvestedYield = taxableInvestedHoldings.length > 0
-    ? estimateAccountYield(taxableInvestedHoldings, ['taxable'], getHoldingYield) / 100
-    : 0;
 
-  ($(`${prefix}TaxableReturn`) as HTMLInputElement).placeholder = fmtD(estimatedInvestedGrowthPct, 1);
-  ($(`${prefix}IraReturn`) as HTMLInputElement).placeholder = fmtD(estimatedInvestedGrowthPct, 1);
-  ($(`${prefix}RothReturn`) as HTMLInputElement).placeholder = fmtD(estimatedInvestedGrowthPct, 1);
+  ($(`${prefix}TaxableReturn`) as HTMLInputElement).placeholder = fmtD(estimatedTaxableGrowthPct, 1);
+  ($(`${prefix}IraReturn`) as HTMLInputElement).placeholder = fmtD(estimatedIraGrowthPct, 1);
+  ($(`${prefix}RothReturn`) as HTMLInputElement).placeholder = fmtD(estimatedRothGrowthPct, 1);
 
   if (holdings.length === 0) {
     $(`${prefix}Assumptions`).innerHTML = '';
@@ -1897,12 +1904,12 @@ function renderLifetimePlan(prefix: 'co' | 'dp', allowConversion: boolean): void
   }
 
   if (allowConversion && iraBalance <= 0) {
-    $(`${prefix}Assumptions`).textContent = `Using holdings-based assumptions. Default invested return is ${fmtD(estimatedInvestedGrowthPct, 1)}% across taxable invested assets, IRA, and Roth/HSA to reflect a rebalanced overall portfolio mix${taxableReturnOverride || iraReturnOverride || rothReturnOverride ? '; manual overrides replace that shared default where entered' : ''}. Taxable cash uses ${fmtD(estimatedTaxableCashGrowthPct, 1)}% unless the taxable override is set.`;
+    $(`${prefix}Assumptions`).textContent = `Using holdings-based assumptions. The simulator rebalances invested assets yearly to your current portfolio mix while preferring tax-efficient placement, so taxable invested defaults to ${fmtD(estimatedTaxableGrowthPct, 1)}%, IRA to ${fmtD(estimatedIraGrowthPct, 1)}%, and Roth/HSA to ${fmtD(estimatedRothGrowthPct, 1)}%${taxableReturnOverride || iraReturnOverride || rothReturnOverride ? '; manual overrides replace those defaults where entered' : ''}. Taxable cash uses ${fmtD(estimatedTaxableCashGrowthPct, 1)}% unless the taxable override is set.`;
     $(`${prefix}Results`).innerHTML = '<div class="co-optimal-callout neutral"><div class="co-optimal-title">No Traditional IRA holdings found.</div><div class="co-optimal-sub">Add or import Traditional IRA holdings to compare conversion scenarios.</div></div>';
     return;
   }
 
-  $(`${prefix}Assumptions`).textContent = `Using current holdings automatically. Retirement earned income is assumed to be $0. Default invested return is ${fmtD(estimatedInvestedGrowthPct, 1)}% across taxable invested assets, IRA, and Roth/HSA so the simulation reflects a rebalanced overall portfolio mix. Taxable invested uses ${fmtD(taxableGrowthPct, 1)}%${taxableReturnOverride ? ` (manual; shared estimate ${fmtD(estimatedInvestedGrowthPct, 1)}%)` : ' (shared portfolio estimate)'}, taxable cash uses ${fmtD(taxableCashGrowthPct, 1)}%${taxableReturnOverride ? ' (matching manual taxable override)' : ' (cash estimate)'}, IRA uses ${fmtD(iraGrowthPct, 1)}%${iraReturnOverride ? ` (manual; shared estimate ${fmtD(estimatedInvestedGrowthPct, 1)}%)` : ' (shared portfolio estimate)'}, and Roth/HSA uses ${fmtD(rothGrowthPct, 1)}%${rothReturnOverride ? ` (manual; shared estimate ${fmtD(estimatedInvestedGrowthPct, 1)}%)` : ' (shared portfolio estimate)'}. Base spending is inflated by ${fmtD(inflation * 100, 1)}% per year. Pre-65 healthcare uses ACA Gold premiums net of subsidies for a household of ${householdSize} with a 50% load and ${fmtD(healthcareInflation * 100, 1)}% healthcare inflation, and 65+ uses the Medicare model for premiums, out-of-pocket, and IRMAA. Taxable cash is spent before selling appreciated taxable assets.${allowConversion ? '' : ' Roth conversions are disabled in this view.'}`;
+  $(`${prefix}Assumptions`).textContent = `Using current holdings automatically. Retirement earned income is assumed to be $0. The simulator rebalances invested assets yearly to your current portfolio mix while preferring bonds and other tax-inefficient assets in IRA first, then Roth/HSA, then taxable if needed. Taxable invested uses ${fmtD(taxableGrowthPct, 1)}%${taxableReturnOverride ? ` (manual; estimated ${fmtD(estimatedTaxableGrowthPct, 1)}%)` : ' (rebalanced taxable mix estimate)'}, taxable cash uses ${fmtD(taxableCashGrowthPct, 1)}%${taxableReturnOverride ? ' (matching manual taxable override)' : ' (cash estimate)'}, IRA uses ${fmtD(iraGrowthPct, 1)}%${iraReturnOverride ? ` (manual; estimated ${fmtD(estimatedIraGrowthPct, 1)}%)` : ' (rebalanced IRA mix estimate)'}, and Roth/HSA uses ${fmtD(rothGrowthPct, 1)}%${rothReturnOverride ? ` (manual; estimated ${fmtD(estimatedRothGrowthPct, 1)}%)` : ' (rebalanced Roth/HSA mix estimate)'}. Base spending is inflated by ${fmtD(inflation * 100, 1)}% per year. Pre-65 healthcare uses ACA Gold premiums net of subsidies for a household of ${householdSize} with a 50% load and ${fmtD(healthcareInflation * 100, 1)}% healthcare inflation, and 65+ uses the Medicare model for premiums, out-of-pocket, and IRMAA. Taxable cash is spent before selling appreciated taxable assets.${allowConversion ? '' : ' Roth conversions are disabled in this view.'}`;
 
   if (startAge >= lifeExp) {
     $(`${prefix}Results`).innerHTML = '<div class="co-optimal-callout neutral"><div class="co-optimal-title">Life expectancy must be greater than current age.</div></div>';
@@ -2159,6 +2166,15 @@ function renderLifetimePlan(prefix: 'co' | 'dp', allowConversion: boolean): void
         rmd = ira / factor;
       }
 
+      const currentRebalancedMix = rebalanceInvestedAccounts(
+        {
+          taxable: Math.max(taxableInvested, 0),
+          ira: Math.max(ira, 0),
+          roth: Math.max(rothExisting + rothConverted, 0),
+        },
+        investedTargetMix,
+      );
+      const taxableInvestedYield = estimateAccountYieldFromBalances(currentRebalancedMix, 'taxable') / 100;
       const recurringTaxableIncome = (taxableCash * taxableCashYield) + (taxableInvested * taxableInvestedYield);
       const baselineOtherOrdinaryIncome = earnedIncome + recurringTaxableIncome + rmd;
       const baselineIncomeState = buildIncomeState(baselineOtherOrdinaryIncome, 0, ssThisYear);
@@ -2341,9 +2357,35 @@ function renderLifetimePlan(prefix: 'co' | 'dp', allowConversion: boolean): void
       const rmdFunding = Math.max(Math.min(totalBaselineFunding - ssFunding, rmdFundingAvailable), 0);
       const yieldFunding = Math.max(totalBaselineFunding - ssFunding - rmdFunding, 0);
 
+      const endOfYearRebalancedMix = rebalanceInvestedAccounts(
+        {
+          taxable: Math.max(taxableInvested, 0),
+          ira: Math.max(ira, 0),
+          roth: Math.max(rothExisting + rothConverted, 0),
+        },
+        investedTargetMix,
+      );
+      const taxableInvestedGrowth = (taxableReturnOverride
+        ? taxableGrowthPct
+        : estimateAccountReturnFromBalances(endOfYearRebalancedMix, 'taxable')) / 100;
+      const iraGrowth = (iraReturnOverride
+        ? iraGrowthPct
+        : estimateAccountReturnFromBalances(endOfYearRebalancedMix, 'ira')) / 100;
+      const rothGrowth = (rothReturnOverride
+        ? rothGrowthPct
+        : estimateAccountReturnFromBalances(endOfYearRebalancedMix, 'roth')) / 100;
+
       ira = Math.max(ira, 0) * (1 + iraGrowth);
-      rothExisting = Math.max(rothExisting, 0) * (1 + rothGrowth);
-      rothConverted = Math.max(rothConverted, 0) * (1 + rothGrowth);
+      const rothTotalBeforeGrowth = Math.max(rothExisting, 0) + Math.max(rothConverted, 0);
+      const rothTotalAfterGrowth = rothTotalBeforeGrowth * (1 + rothGrowth);
+      if (rothTotalBeforeGrowth > 0) {
+        const rothGrowthFactor = rothTotalAfterGrowth / rothTotalBeforeGrowth;
+        rothExisting = Math.max(rothExisting, 0) * rothGrowthFactor;
+        rothConverted = Math.max(rothConverted, 0) * rothGrowthFactor;
+      } else {
+        rothExisting = 0;
+        rothConverted = 0;
+      }
       taxableCash = Math.max(taxableCash, 0) * (1 + taxableCashGrowth);
       taxableInvested = Math.max(taxableInvested, 0) * (1 + taxableInvestedGrowth);
       taxableCostBasis = Math.max(taxableCostBasis, 0) * (1 + taxableInvestedGrowth * 0.3);
@@ -2600,7 +2642,7 @@ function renderLifetimePlan(prefix: 'co' | 'dp', allowConversion: boolean): void
         ${strategyDesc[strategy]}
         Both scenarios start with $${fmt(annualSpending)}/yr spending, inflated ${fmtD(inflation * 100, 1)}% annually, plus healthcare costs.
         Withdrawal order: RMDs first, then taxable (long-term capital gains brackets), then IRA (ordinary income brackets), then Roth/HSA (modeled as tax-free).
-        Invested growth assumptions come from your overall portfolio mix, with taxable cash modeled separately unless you override the return inputs above.
+        Invested growth assumptions come from a yearly rebalance back to your current portfolio mix, with tax-location preferences applied across taxable, IRA, and Roth/HSA. Taxable cash is modeled separately unless you override the return inputs above.
         Heir taxes assume a non-spouse heir withdraws the inherited IRA evenly over 10 years and pays ordinary federal income tax under the same tax table model.
         <br>* = Medicare (65+). + = RMDs begin (73+).
       </p>

--- a/tests/calc/rebalance.test.ts
+++ b/tests/calc/rebalance.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import type { Holding } from '../../src/types';
+import {
+  deriveInvestedTargetMix,
+  estimateAccountReturnFromBalances,
+  estimateAccountYieldFromBalances,
+  growRebalancedAccounts,
+  rebalanceInvestedAccounts,
+  getAccountBalance,
+} from '../../src/calc/rebalance';
+
+const makeHolding = (overrides: Partial<Holding>): Holding => ({
+  ticker: 'VTI',
+  name: 'Test Holding',
+  account: 'taxable',
+  category: 'us_stock',
+  shares: 100,
+  costBasis: 100,
+  price: 100,
+  dividendYield: 1.0,
+  ...overrides,
+});
+
+describe('deriveInvestedTargetMix', () => {
+  it('ignores cash and normalizes the invested mix', () => {
+    const holdings = [
+      makeHolding({ account: 'taxable', category: 'us_stock', shares: 60, price: 100 }),
+      makeHolding({ account: 'ira', category: 'bond', shares: 40, price: 100 }),
+      makeHolding({ account: 'taxable', category: 'cash', shares: 20, price: 100 }),
+    ];
+
+    const mix = deriveInvestedTargetMix(holdings);
+    expect(mix.us_stock).toBeCloseTo(0.6, 6);
+    expect(mix.bond).toBeCloseTo(0.4, 6);
+    expect(mix.cash).toBe(0);
+  });
+});
+
+describe('rebalanceInvestedAccounts', () => {
+  it('prefers bonds in IRA before other accounts', () => {
+    const rebalanced = rebalanceInvestedAccounts(
+      { taxable: 20000, ira: 50000, roth: 30000 },
+      { us_stock: 0.6, intl_stock: 0, bond: 0.4, muni: 0, reit: 0, cash: 0, crypto: 0, other: 0 },
+    );
+
+    expect(rebalanced.ira.bond).toBeCloseTo(40000, 6);
+    expect(rebalanced.taxable.bond).toBeCloseTo(0, 6);
+    expect(getAccountBalance(rebalanced, 'taxable')).toBeCloseTo(20000, 6);
+    expect(getAccountBalance(rebalanced, 'ira')).toBeCloseTo(50000, 6);
+    expect(getAccountBalance(rebalanced, 'roth')).toBeCloseTo(30000, 6);
+  });
+
+  it('spills bonds into Roth when IRA capacity is not enough', () => {
+    const rebalanced = rebalanceInvestedAccounts(
+      { taxable: 20000, ira: 30000, roth: 50000 },
+      { us_stock: 0.2, intl_stock: 0, bond: 0.8, muni: 0, reit: 0, cash: 0, crypto: 0, other: 0 },
+    );
+
+    expect(rebalanced.ira.bond).toBeCloseTo(30000, 6);
+    expect(rebalanced.roth.bond).toBeCloseTo(50000, 6);
+    expect(rebalanced.taxable.us_stock).toBeCloseTo(20000, 6);
+  });
+});
+
+describe('account mix estimates', () => {
+  it('derives blended account return and yield from rebalanced composition', () => {
+    const rebalanced = rebalanceInvestedAccounts(
+      { taxable: 20000, ira: 50000, roth: 30000 },
+      { us_stock: 0.6, intl_stock: 0, bond: 0.4, muni: 0, reit: 0, cash: 0, crypto: 0, other: 0 },
+    );
+
+    expect(estimateAccountReturnFromBalances(rebalanced, 'taxable')).toBeCloseTo(7.0, 6);
+    expect(estimateAccountReturnFromBalances(rebalanced, 'ira')).toBeCloseTo((40000 * 3.5 + 10000 * 7.0) / 50000, 6);
+    expect(estimateAccountYieldFromBalances(rebalanced, 'ira')).toBeCloseTo((40000 * 3.5 + 10000 * 1.3) / 50000, 6);
+  });
+
+  it('applies category growth inside each account', () => {
+    const rebalanced = rebalanceInvestedAccounts(
+      { taxable: 20000, ira: 50000, roth: 30000 },
+      { us_stock: 0.6, intl_stock: 0, bond: 0.4, muni: 0, reit: 0, cash: 0, crypto: 0, other: 0 },
+    );
+
+    const grown = growRebalancedAccounts(rebalanced);
+    expect(getAccountBalance(grown, 'taxable')).toBeCloseTo(20000 * 1.07, 4);
+    expect(getAccountBalance(grown, 'ira')).toBeCloseTo(40000 * 1.035 + 10000 * 1.07, 4);
+  });
+});


### PR DESCRIPTION
## Summary
- rebalance invested assets yearly across taxable invested, IRA, and Roth/HSA using the portfolio\'s invested mix and tax-location preferences
- derive account-specific blended returns and taxable-invested yield from the rebalanced account mix instead of a flat shared rate
- add a pure rebalance helper with unit coverage and update the planner copy to explain the yearly rebalance model

## Testing
- npm test
- npm run build

Closes #18