### PR TITLE
Fix conversion table render hotfix

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -2401,7 +2401,7 @@ function renderLifetimePlan(prefix: 'co' | 'dp', allowConversion: boolean): void
       taxableCash = Math.max(taxableCash, 0) * (1 + taxableCashGrowth);
       taxableInvested = Math.max(taxableInvested, 0) * (1 + taxableInvestedGrowth);
       taxableCostBasis = Math.max(taxableCostBasis, 0) * (1 + taxableInvestedGrowth * 0.3);
-      roth = rothExisting + rothConverted;
+      const roth = rothExisting + rothConverted;
       const endingTaxable = taxableCash + taxableInvested;
 
       years.push({


### PR DESCRIPTION
## Summary
- fix a runtime ReferenceError in the lifetime simulation render path introduced by the iterative solver change
- restore conversion and drawdown table rendering
- keep the iterative solver logic intact

## Testing
- npm test
- npm run build

Closes #22