### PR TITLE
Make conversion recommendation depletion-aware

### DIFF
--- a/src/calc/conversion.ts
+++ b/src/calc/conversion.ts
@@ -1,5 +1,5 @@
 export type RothConversionAction = 'convert' | 'do_not_convert';
-export type RothConversionDriver = 'wealth' | 'tax';
+export type RothConversionDriver = 'depletion' | 'wealth' | 'tax';
 export type RothConversionTone = 'positive' | 'negative' | 'neutral';
 
 export interface RothConversionRecommendation {
@@ -14,7 +14,23 @@ const MATERIAL_TAX_DIFF = 1000;
 export function recommendRothConversion(
   wealthDiff: number,
   taxDiff: number,
+  withConversionRanOutAge: number | null,
+  withoutConversionRanOutAge: number | null,
 ): RothConversionRecommendation {
+  if (withConversionRanOutAge !== withoutConversionRanOutAge) {
+    if (withConversionRanOutAge === null) {
+      return { action: 'convert', driver: 'depletion', tone: 'positive' };
+    }
+    if (withoutConversionRanOutAge === null) {
+      return { action: 'do_not_convert', driver: 'depletion', tone: 'negative' };
+    }
+    if (withConversionRanOutAge < withoutConversionRanOutAge) {
+      return { action: 'do_not_convert', driver: 'depletion', tone: 'negative' };
+    }
+    if (withConversionRanOutAge > withoutConversionRanOutAge) {
+      return { action: 'convert', driver: 'depletion', tone: 'positive' };
+    }
+  }
   if (wealthDiff > MATERIAL_WEALTH_DIFF) {
     return { action: 'convert', driver: 'wealth', tone: 'positive' };
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -2462,7 +2462,7 @@ function renderLifetimePlan(prefix: 'co' | 'dp', allowConversion: boolean): void
   const taxDiff = withConv.totalTaxPaid - noConv.totalTaxPaid;
   const subsidyDiff = withConv.totalSubsidyReceived - noConv.totalSubsidyReceived;
   const wealthDiff = withConv.endOfLifeWealth - noConv.endOfLifeWealth;
-  const recommendation = recommendRothConversion(wealthDiff, taxDiff);
+  const recommendation = recommendRothConversion(wealthDiff, taxDiff, withConv.ranOutAge, noConv.ranOutAge);
   const shouldConvert = recommendation.action === 'convert';
 
   const strategyDesc: Record<string, string> = {
@@ -2519,11 +2519,15 @@ function renderLifetimePlan(prefix: 'co' | 'dp', allowConversion: boolean): void
     : recommendation.tone === 'negative'
       ? 'var(--red)'
       : 'var(--text)';
-  const recommendationWhy = recommendation.driver === 'wealth'
-    ? Math.abs(wealthDiff) <= 1000
-      ? `Modeled end-of-life wealth is roughly flat. Lifetime taxes are ${taxDirection}${taxDiff === 0 ? '' : ` by ${fmtAbsCoMoney(taxDiff)}`}.`
-      : `Modeled end-of-life wealth is ${wealthDirection} by ${fmtAbsCoMoney(wealthDiff)} with conversions. Lifetime taxes are ${taxDirection}${taxDiff === 0 ? '' : ` by ${fmtAbsCoMoney(taxDiff)}`}.`
-    : `End-of-life wealth is roughly flat, but lifetime taxes are ${taxDirection}${taxDiff === 0 ? '' : ` by ${fmtAbsCoMoney(taxDiff)}`} with conversions.`;
+  const recommendationWhy = recommendation.driver === 'depletion'
+    ? shouldConvert
+      ? `Conversions keep the plan funded longer${noConv.ranOutAge !== null ? ` by avoiding depletion at age ${noConv.ranOutAge}` : ''}.`
+      : `Conversions deplete the plan earlier${withConv.ranOutAge !== null ? ` at age ${withConv.ranOutAge}` : ''}, so they are not preferred even if taxes are lower.`
+    : recommendation.driver === 'wealth'
+      ? Math.abs(wealthDiff) <= 1000
+        ? `Modeled end-of-life wealth is roughly flat. Lifetime taxes are ${taxDirection}${taxDiff === 0 ? '' : ` by ${fmtAbsCoMoney(taxDiff)}`}.`
+        : `Modeled end-of-life wealth is ${wealthDirection} by ${fmtAbsCoMoney(wealthDiff)} with conversions. Lifetime taxes are ${taxDirection}${taxDiff === 0 ? '' : ` by ${fmtAbsCoMoney(taxDiff)}`}.`
+      : `End-of-life wealth is roughly flat, but lifetime taxes are ${taxDirection}${taxDiff === 0 ? '' : ` by ${fmtAbsCoMoney(taxDiff)}`} with conversions.`;
   const recommendationSecondary = subsidyDiff < -1000
     ? `A loss of ${fmtAbsCoMoney(subsidyDiff)} in ACA subsidies is part of the drag.`
     : subsidyDiff > 1000

--- a/tests/calc/conversion.test.ts
+++ b/tests/calc/conversion.test.ts
@@ -3,7 +3,7 @@ import { recommendRothConversion } from '../../src/calc/conversion';
 
 describe('recommendRothConversion', () => {
   it('recommends converting when end-of-life wealth is materially higher', () => {
-    expect(recommendRothConversion(5000, 2000)).toEqual({
+    expect(recommendRothConversion(5000, 2000, null, null)).toEqual({
       action: 'convert',
       driver: 'wealth',
       tone: 'positive',
@@ -11,7 +11,7 @@ describe('recommendRothConversion', () => {
   });
 
   it('recommends against converting when end-of-life wealth is materially lower', () => {
-    expect(recommendRothConversion(-5000, -2000)).toEqual({
+    expect(recommendRothConversion(-5000, -2000, null, null)).toEqual({
       action: 'do_not_convert',
       driver: 'wealth',
       tone: 'negative',
@@ -19,7 +19,7 @@ describe('recommendRothConversion', () => {
   });
 
   it('uses tax savings as the tiebreaker when wealth is roughly flat', () => {
-    expect(recommendRothConversion(500, -3000)).toEqual({
+    expect(recommendRothConversion(500, -3000, null, null)).toEqual({
       action: 'convert',
       driver: 'tax',
       tone: 'positive',
@@ -27,10 +27,26 @@ describe('recommendRothConversion', () => {
   });
 
   it('defaults to no conversion when wealth is flat and taxes are not lower', () => {
-    expect(recommendRothConversion(500, 200)).toEqual({
+    expect(recommendRothConversion(500, 200, null, null)).toEqual({
       action: 'do_not_convert',
       driver: 'wealth',
       tone: 'neutral',
+    });
+  });
+
+  it('recommends against converting when conversions deplete earlier', () => {
+    expect(recommendRothConversion(5000, -3000, 82, null)).toEqual({
+      action: 'do_not_convert',
+      driver: 'depletion',
+      tone: 'negative',
+    });
+  });
+
+  it('recommends converting when conversions avoid depletion', () => {
+    expect(recommendRothConversion(-5000, 3000, null, 82)).toEqual({
+      action: 'convert',
+      driver: 'depletion',
+      tone: 'positive',
     });
   });
 });


### PR DESCRIPTION
## Summary
- feed depletion timing into the Roth conversion recommendation logic so earlier failure outweighs tax savings
- explain earlier depletion directly in the recommendation copy when it is the deciding factor
- add unit coverage for the new depletion-aware rule

## Testing
- npm test
- npm run build

Closes #24