### PR TITLE
Use holdings-based planner net worth by default

### DIFF
--- a/src/calc/portfolio-balance.ts
+++ b/src/calc/portfolio-balance.ts
@@ -1,0 +1,60 @@
+import type { Holding } from '../types';
+
+export interface HoldingBalances {
+  taxable: number;
+  taxableBasis: number;
+  taxableCash: number;
+  taxableInvested: number;
+  taxableInvestedBasis: number;
+  ira: number;
+  roth: number;
+  hsa: number;
+}
+
+export function getHoldingBalances(holdings: Holding[]): HoldingBalances {
+  let taxable = 0;
+  let taxableBasis = 0;
+  let taxableCash = 0;
+  let taxableInvested = 0;
+  let taxableInvestedBasis = 0;
+  let ira = 0;
+  let roth = 0;
+  let hsa = 0;
+
+  for (const holding of holdings) {
+    const value = holding.shares * holding.price;
+    const cost = holding.shares * holding.costBasis;
+
+    if (holding.account === 'taxable') {
+      taxable += value;
+      taxableBasis += cost;
+      if (holding.category === 'cash') {
+        taxableCash += value;
+      } else {
+        taxableInvested += value;
+        taxableInvestedBasis += cost;
+      }
+    } else if (holding.account === 'ira') {
+      ira += value;
+    } else if (holding.account === 'roth') {
+      roth += value;
+    } else if (holding.account === 'hsa') {
+      hsa += value;
+    }
+  }
+
+  return { taxable, taxableBasis, taxableCash, taxableInvested, taxableInvestedBasis, ira, roth, hsa };
+}
+
+export function getPortfolioNetWorthFromBalances(balances: HoldingBalances): number {
+  return balances.taxable + balances.ira + balances.roth + balances.hsa;
+}
+
+export function getPortfolioNetWorth(holdings: Holding[]): number {
+  return getPortfolioNetWorthFromBalances(getHoldingBalances(holdings));
+}
+
+export function resolvePlannerStartingNetWorth(holdings: Holding[], manualNetWorth: number): number {
+  const holdingsNetWorth = getPortfolioNetWorth(holdings);
+  return holdings.length > 0 && holdingsNetWorth > 0 ? holdingsNetWorth : manualNetWorth;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,7 @@ import {
   estimateAccountYieldFromBalances,
   rebalanceInvestedAccounts,
 } from './calc/rebalance';
+import { getHoldingBalances, getPortfolioNetWorth, resolvePlannerStartingNetWorth } from './calc/portfolio-balance';
 import {
   buildDealchartsQueries,
   emptySymbolLookupResult,
@@ -174,8 +175,9 @@ const APP_HTML = `
         </div>
 
         <div class="planner-field">
-          <label for="currentSavings">Current Net Worth</label>
+          <label for="currentSavings" id="currentSavingsLabel">Current Net Worth</label>
           <input type="number" id="currentSavings" value="50000" step="1000">
+          <div class="planner-hint" id="currentSavingsHint">Enter your current investable net worth.</div>
         </div>
 
         <div class="planner-row">
@@ -1098,6 +1100,28 @@ function syncRetireExpensesFromCurrent(): void {
   $('retireExpenses').value = $('annualExpenses').value;
 }
 
+function updatePlannerFundingSourceControls(): void {
+  const savingsInput = $('currentSavings') as HTMLInputElement;
+  const savingsLabel = $('currentSavingsLabel');
+  const savingsHint = $('currentSavingsHint');
+  const holdingsNetWorth = getPortfolioNetWorth(holdings);
+  const hasImportedHoldings = holdings.length > 0 && holdingsNetWorth > 0;
+
+  if (hasImportedHoldings) {
+    savingsLabel.textContent = 'Portfolio Net Worth (from holdings)';
+    savingsInput.value = String(Math.round(holdingsNetWorth));
+    savingsInput.readOnly = true;
+    savingsInput.setAttribute('aria-readonly', 'true');
+    savingsHint.textContent = 'Derived automatically from your imported holdings. Add planner adjustments in the next step if you need to include assets outside this portfolio.';
+    return;
+  }
+
+  savingsLabel.textContent = 'Current Net Worth';
+  savingsInput.readOnly = false;
+  savingsInput.removeAttribute('aria-readonly');
+  savingsHint.textContent = 'Enter your current investable net worth.';
+}
+
 function attachGlobals(): void {
   Object.assign(win, {
     exportBackup,
@@ -1148,6 +1172,7 @@ function renderPortfolio(): void {
 }
 
 function readPlannerInputs() {
+  const plannerStartingNetWorth = resolvePlannerStartingNetWorth(holdings, readFloat('currentSavings', 50000));
   return {
     currentAge: readInt('currentAge', 30),
     filingStatus: readFilingStatus(),
@@ -1157,7 +1182,7 @@ function readPlannerInputs() {
     spouseRetirementAge: readInt('spouseRetirementAge', readInt('spouseAge', readInt('currentAge', 30))),
     annualIncome: readFloat('annualIncome', 100000),
     annualExpenses: readFloat('annualExpenses', 40000),
-    currentSavings: readFloat('currentSavings', 50000),
+    currentSavings: plannerStartingNetWorth,
     returnRate: readFloat('returnRate', 7),
     inflationRate: readFloat('inflationRate', 3),
     withdrawalRate: readFloat('withdrawalRate', 4),
@@ -1497,6 +1522,7 @@ function deletePlanningScenario(id: string): void {
 }
 
 function renderPlanner(forceChart = false, syncRetirementAge = true): void {
+  updatePlannerFundingSourceControls();
   const result = getPlannerResult();
   if (syncRetirementAge) syncRetirementAgeDefault();
   renderPlannerPage(result, forceChart || $('pagePlanner').classList.contains('active'));
@@ -1606,56 +1632,13 @@ function clearSymbolRefreshReport(): void {
   renderSymbolRefreshReport();
 }
 
-function getHoldingBalances(): {
-  taxable: number;
-  taxableBasis: number;
-  taxableCash: number;
-  taxableInvested: number;
-  taxableInvestedBasis: number;
-  ira: number;
-  roth: number;
-  hsa: number;
-} {
-  let taxable = 0;
-  let taxableBasis = 0;
-  let taxableCash = 0;
-  let taxableInvested = 0;
-  let taxableInvestedBasis = 0;
-  let ira = 0;
-  let roth = 0;
-  let hsa = 0;
-
-  for (const h of holdings) {
-    const value = h.shares * h.price;
-    const cost = h.shares * h.costBasis;
-    if (h.account === 'taxable') {
-      taxable += value;
-      taxableBasis += cost;
-      if (h.category === 'cash') {
-        taxableCash += value;
-      } else {
-        taxableInvested += value;
-        taxableInvestedBasis += cost;
-      }
-    } else if (h.account === 'ira') {
-      ira += value;
-    } else if (h.account === 'roth') {
-      roth += value;
-    } else if (h.account === 'hsa') {
-      hsa += value;
-    }
-  }
-
-  return { taxable, taxableBasis, taxableCash, taxableInvested, taxableInvestedBasis, ira, roth, hsa };
-}
-
 function renderDrawdown(): void {
   if (holdings.length === 0) {
     $('drawdownArea').innerHTML = '<div class="empty-state"><p>Add holdings to see drawdown analysis.</p></div>';
     return;
   }
 
-  const balances = getHoldingBalances();
+  const balances = getHoldingBalances(holdings);
   const retireAge = readRetirementAge();
   const currentAge = retireAge;
   const expenses = readFloat('ddExpenses', 40000);
@@ -2236,7 +2219,7 @@ function renderMedicareProjection(): void {
 }
 
 function renderLifetimePlan(prefix: 'co' | 'dp', allowConversion: boolean): void {
-  const portfolioBalances = getHoldingBalances();
+  const portfolioBalances = getHoldingBalances(holdings);
   const startAge = readRetirementAge();
   const lifeExp = readInt(`${prefix}LifeExp`, 90);
   const earnedIncome = 0;

--- a/tests/calc/portfolio-balance.test.ts
+++ b/tests/calc/portfolio-balance.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getHoldingBalances,
+  getPortfolioNetWorth,
+  getPortfolioNetWorthFromBalances,
+  resolvePlannerStartingNetWorth,
+} from '../../src/calc/portfolio-balance';
+import type { Holding } from '../../src/types';
+
+const holdings: Holding[] = [
+  { ticker: 'VMFXX', name: 'Cash', account: 'taxable', category: 'cash', shares: 1000, costBasis: 1, price: 1, dividendYield: 4 },
+  { ticker: 'VTI', name: 'US Stock', account: 'taxable', category: 'us_stock', shares: 50, costBasis: 200, price: 300, dividendYield: 1.3 },
+  { ticker: 'BND', name: 'Bond', account: 'ira', category: 'bond', shares: 100, costBasis: 70, price: 72, dividendYield: 3.5 },
+  { ticker: 'VXUS', name: 'Intl', account: 'roth', category: 'intl_stock', shares: 80, costBasis: 50, price: 60, dividendYield: 3 },
+  { ticker: 'VUSXX', name: 'Treasury MMF', account: 'hsa', category: 'cash', shares: 500, costBasis: 1, price: 1, dividendYield: 4 },
+];
+
+describe('portfolio-balance helpers', () => {
+  it('splits holdings into taxable cash, taxable invested, and tax-advantaged balances', () => {
+    const balances = getHoldingBalances(holdings);
+
+    expect(balances.taxableCash).toBe(1000);
+    expect(balances.taxableInvested).toBe(15000);
+    expect(balances.taxable).toBe(16000);
+    expect(balances.taxableBasis).toBe(11000);
+    expect(balances.taxableInvestedBasis).toBe(10000);
+    expect(balances.ira).toBe(7200);
+    expect(balances.roth).toBe(4800);
+    expect(balances.hsa).toBe(500);
+  });
+
+  it('computes total portfolio net worth from balances or holdings', () => {
+    const balances = getHoldingBalances(holdings);
+
+    expect(getPortfolioNetWorthFromBalances(balances)).toBe(28500);
+    expect(getPortfolioNetWorth(holdings)).toBe(28500);
+  });
+
+  it('uses holdings for planner starting net worth when holdings exist, otherwise falls back to manual net worth', () => {
+    expect(resolvePlannerStartingNetWorth(holdings, 123456)).toBe(28500);
+    expect(resolvePlannerStartingNetWorth([], 123456)).toBe(123456);
+  });
+});


### PR DESCRIPTION
## Summary
- derive planner starting net worth from imported holdings by default
- extract shared portfolio balance helpers for planner and retirement views
- update planner copy to show when net worth is coming from holdings

## Testing
- npm test
- npm run build

Closes #33