### PR TITLE
Add planner funding reconciliation inputs

### DIFF
--- a/src/calc/fire.ts
+++ b/src/calc/fire.ts
@@ -90,7 +90,7 @@ export function calculateFirePlan(inputs: FirePlannerInputs): FirePlannerResult 
   const annualIncome = Math.max(inputs.annualIncome || 0, 0);
   const spouseAnnualIncome = filingStatus === 'married' ? Math.max(inputs.spouseAnnualIncome || 0, 0) : 0;
   const annualExpenses = Math.max(inputs.annualExpenses || 0, 0);
-  const currentSavings = Math.max(inputs.currentSavings || 0, 0);
+  const currentSavings = Number.isFinite(inputs.currentSavings) ? (inputs.currentSavings as number) : 0;
   const returnRate = Math.max(inputs.returnRate || 0, 0) / 100;
   const inflationRate = Math.max(inputs.inflationRate || 0, 0) / 100;
   const withdrawalRate = Math.max(inputs.withdrawalRate || 0, 0.01) / 100;

--- a/src/calc/portfolio-balance.ts
+++ b/src/calc/portfolio-balance.ts
@@ -11,6 +11,13 @@ export interface HoldingBalances {
   hsa: number;
 }
 
+export interface PlannerFundingSource {
+  holdingsNetWorth: number;
+  otherAssetsAdjustment: number;
+  liabilitiesAdjustment: number;
+  startingNetWorth: number;
+}
+
 export function getHoldingBalances(holdings: Holding[]): HoldingBalances {
   let taxable = 0;
   let taxableBasis = 0;
@@ -54,7 +61,17 @@ export function getPortfolioNetWorth(holdings: Holding[]): number {
   return getPortfolioNetWorthFromBalances(getHoldingBalances(holdings));
 }
 
-export function resolvePlannerStartingNetWorth(holdings: Holding[], manualNetWorth: number): number {
+export function calculatePlannerFundingSource(
+  holdings: Holding[],
+  otherAssetsAdjustment = 0,
+  liabilitiesAdjustment = 0,
+): PlannerFundingSource {
   const holdingsNetWorth = getPortfolioNetWorth(holdings);
-  return holdings.length > 0 && holdingsNetWorth > 0 ? holdingsNetWorth : manualNetWorth;
+  const normalizedLiabilitiesAdjustment = Math.max(liabilitiesAdjustment, 0);
+  return {
+    holdingsNetWorth,
+    otherAssetsAdjustment,
+    liabilitiesAdjustment: normalizedLiabilitiesAdjustment,
+    startingNetWorth: holdingsNetWorth + otherAssetsAdjustment - normalizedLiabilitiesAdjustment,
+  };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ import {
   estimateAccountYieldFromBalances,
   rebalanceInvestedAccounts,
 } from './calc/rebalance';
-import { getHoldingBalances, getPortfolioNetWorth, resolvePlannerStartingNetWorth } from './calc/portfolio-balance';
+import { calculatePlannerFundingSource, getHoldingBalances } from './calc/portfolio-balance';
 import {
   buildDealchartsQueries,
   emptySymbolLookupResult,
@@ -174,11 +174,32 @@ const APP_HTML = `
           <div class="planner-hint">Your current yearly spending in today's dollars</div>
         </div>
 
-        <div class="planner-field">
-          <label for="currentSavings" id="currentSavingsLabel">Current Net Worth</label>
-          <input type="number" id="currentSavings" value="50000" step="1000">
-          <div class="planner-hint" id="currentSavingsHint">Enter your current investable net worth.</div>
+        <div class="planner-row">
+          <div class="planner-field">
+            <label for="portfolioNetWorth">Portfolio Holdings Net Worth</label>
+            <input type="number" id="portfolioNetWorth" value="0" step="1000" readonly>
+            <div class="planner-hint">Derived automatically from imported holdings tracked in this app.</div>
+          </div>
+          <div class="planner-field">
+            <label for="otherAssetsAdjustment">Other Assets Adjustment</label>
+            <input type="number" id="otherAssetsAdjustment" value="0" step="1000">
+            <div class="planner-hint">Add outside assets not represented in your holdings, such as home equity allocated to retirement or private investments.</div>
+          </div>
         </div>
+
+        <div class="planner-row">
+          <div class="planner-field">
+            <label for="liabilitiesAdjustment">Liabilities Adjustment</label>
+            <input type="number" id="liabilitiesAdjustment" value="0" step="1000" min="0">
+            <div class="planner-hint">Subtract debts or obligations that should reduce the planner starting balance.</div>
+          </div>
+          <div class="planner-field">
+            <label for="currentSavings" id="currentSavingsLabel">Planner Starting Net Worth</label>
+            <input type="number" id="currentSavings" value="50000" step="1000" readonly>
+            <div class="planner-hint" id="currentSavingsHint">Portfolio holdings plus other assets minus liabilities.</div>
+          </div>
+        </div>
+        <div class="planner-hint" id="plannerFundingReconciliation" style="margin-top:-0.25rem;margin-bottom:1rem;"></div>
 
         <div class="planner-row">
           <div class="planner-field">
@@ -830,6 +851,8 @@ const plannerInputIds = [
   'spouseRetirementAge',
   'annualIncome',
   'annualExpenses',
+  'otherAssetsAdjustment',
+  'liabilitiesAdjustment',
   'currentSavings',
   'returnRate',
   'inflationRate',
@@ -953,6 +976,8 @@ function emptyPlannerInputSnapshot(): PlannerInputSnapshot {
     spouseRetirementAge: '67',
     annualIncome: '100000',
     annualExpenses: '40000',
+    otherAssetsAdjustment: '0',
+    liabilitiesAdjustment: '0',
     currentSavings: '50000',
     returnRate: '7',
     inflationRate: '3',
@@ -1101,25 +1126,28 @@ function syncRetireExpensesFromCurrent(): void {
 }
 
 function updatePlannerFundingSourceControls(): void {
+  const portfolioInput = $('portfolioNetWorth') as HTMLInputElement;
   const savingsInput = $('currentSavings') as HTMLInputElement;
   const savingsLabel = $('currentSavingsLabel');
   const savingsHint = $('currentSavingsHint');
-  const holdingsNetWorth = getPortfolioNetWorth(holdings);
-  const hasImportedHoldings = holdings.length > 0 && holdingsNetWorth > 0;
+  const reconciliation = $('plannerFundingReconciliation');
+  const funding = calculatePlannerFundingSource(
+    holdings,
+    readFloat('otherAssetsAdjustment', 0),
+    readFloat('liabilitiesAdjustment', 0),
+  );
 
-  if (hasImportedHoldings) {
-    savingsLabel.textContent = 'Portfolio Net Worth (from holdings)';
-    savingsInput.value = String(Math.round(holdingsNetWorth));
-    savingsInput.readOnly = true;
-    savingsInput.setAttribute('aria-readonly', 'true');
-    savingsHint.textContent = 'Derived automatically from your imported holdings. Add planner adjustments in the next step if you need to include assets outside this portfolio.';
-    return;
-  }
-
-  savingsLabel.textContent = 'Current Net Worth';
-  savingsInput.readOnly = false;
-  savingsInput.removeAttribute('aria-readonly');
-  savingsHint.textContent = 'Enter your current investable net worth.';
+  portfolioInput.value = String(Math.round(funding.holdingsNetWorth));
+  savingsLabel.textContent = 'Planner Starting Net Worth';
+  savingsInput.value = String(Math.round(funding.startingNetWorth));
+  savingsInput.setAttribute('aria-readonly', 'true');
+  savingsHint.textContent = 'Portfolio holdings plus other assets minus liabilities.';
+  savingsInput.readOnly = true;
+  reconciliation.innerHTML = `
+    Portfolio holdings $${fmt(Math.round(funding.holdingsNetWorth))}
+    ${funding.otherAssetsAdjustment !== 0 ? ` + other assets $${fmt(Math.round(funding.otherAssetsAdjustment))}` : ' + other assets $0'}
+    ${funding.liabilitiesAdjustment !== 0 ? ` - liabilities $${fmt(Math.round(funding.liabilitiesAdjustment))}` : ' - liabilities $0'}
+    = planner starting net worth <strong>$${fmt(Math.round(funding.startingNetWorth))}</strong>.`;
 }
 
 function attachGlobals(): void {
@@ -1172,7 +1200,11 @@ function renderPortfolio(): void {
 }
 
 function readPlannerInputs() {
-  const plannerStartingNetWorth = resolvePlannerStartingNetWorth(holdings, readFloat('currentSavings', 50000));
+  const funding = calculatePlannerFundingSource(
+    holdings,
+    readFloat('otherAssetsAdjustment', 0),
+    readFloat('liabilitiesAdjustment', 0),
+  );
   return {
     currentAge: readInt('currentAge', 30),
     filingStatus: readFilingStatus(),
@@ -1182,7 +1214,7 @@ function readPlannerInputs() {
     spouseRetirementAge: readInt('spouseRetirementAge', readInt('spouseAge', readInt('currentAge', 30))),
     annualIncome: readFloat('annualIncome', 100000),
     annualExpenses: readFloat('annualExpenses', 40000),
-    currentSavings: plannerStartingNetWorth,
+    currentSavings: funding.startingNetWorth,
     returnRate: readFloat('returnRate', 7),
     inflationRate: readFloat('inflationRate', 3),
     withdrawalRate: readFloat('withdrawalRate', 4),
@@ -1232,6 +1264,7 @@ function applyDrawdownInputSnapshot(snapshot: Partial<DrawdownInputSnapshot>): v
 }
 
 function persistPlannerInputs(): void {
+  updatePlannerFundingSourceControls();
   localStorage.setItem(PLANNER_INPUTS_STORAGE_KEY, JSON.stringify(readPlannerInputSnapshot()));
 }
 
@@ -4429,6 +4462,8 @@ function loadDemoPortfolio(event: Event): void {
     spouseRetirementAge: '67',
     annualIncome: '100000',
     annualExpenses: '40000',
+    otherAssetsAdjustment: '0',
+    liabilitiesAdjustment: '0',
     currentSavings: '250000',
     returnRate: '7',
     inflationRate: '3',

--- a/tests/calc/fire.test.ts
+++ b/tests/calc/fire.test.ts
@@ -126,6 +126,25 @@ describe('calculateFirePlan', () => {
     expect(result.netWorths[3]).toBe(165500);
   });
 
+  it('preserves negative starting net worth when liabilities exceed assets', () => {
+    const result = calculateFirePlan({
+      currentAge: 30,
+      annualIncome: 100000,
+      annualExpenses: 50000,
+      currentSavings: -25000,
+      returnRate: 0,
+      inflationRate: 0,
+      withdrawalRate: 4,
+      taxRate: 0,
+      retireExpenses: 1000000,
+      longevityAge: 95,
+    });
+
+    expect(result.currentSavings).toBe(-25000);
+    expect(result.netWorths[0]).toBe(-25000);
+    expect(result.netWorths[1]).toBe(25000);
+  });
+
   it('reduces the required retirement target when Social Security is modeled', () => {
     const withoutSs = calculateFirePlan({
       currentAge: 40,

--- a/tests/calc/portfolio-balance.test.ts
+++ b/tests/calc/portfolio-balance.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  calculatePlannerFundingSource,
   getHoldingBalances,
   getPortfolioNetWorth,
   getPortfolioNetWorthFromBalances,
-  resolvePlannerStartingNetWorth,
 } from '../../src/calc/portfolio-balance';
 import type { Holding } from '../../src/types';
 
@@ -36,8 +36,12 @@ describe('portfolio-balance helpers', () => {
     expect(getPortfolioNetWorth(holdings)).toBe(28500);
   });
 
-  it('uses holdings for planner starting net worth when holdings exist, otherwise falls back to manual net worth', () => {
-    expect(resolvePlannerStartingNetWorth(holdings, 123456)).toBe(28500);
-    expect(resolvePlannerStartingNetWorth([], 123456)).toBe(123456);
+  it('reconciles holdings, outside assets, and liabilities into planner starting net worth', () => {
+    const funding = calculatePlannerFundingSource(holdings, 50000, 10000);
+
+    expect(funding.holdingsNetWorth).toBe(28500);
+    expect(funding.otherAssetsAdjustment).toBe(50000);
+    expect(funding.liabilitiesAdjustment).toBe(10000);
+    expect(funding.startingNetWorth).toBe(68500);
   });
 });


### PR DESCRIPTION
## Summary
- replace the old manual net-worth workflow with holdings plus adjustments reconciliation
- compute planner starting net worth from portfolio holdings, outside assets, and liabilities
- allow negative starting net worth to flow through the FIRE calculation when liabilities exceed assets

## Testing
- npm test
- npm run build

Closes #30