### PR TITLE
Show account-aware portfolio mix in planner

### DIFF
--- a/src/calc/portfolio-balance.ts
+++ b/src/calc/portfolio-balance.ts
@@ -18,6 +18,16 @@ export interface PlannerFundingSource {
   startingNetWorth: number;
 }
 
+export interface PlannerPortfolioContext {
+  totalNetWorth: number;
+  taxableInvested: number;
+  taxableCash: number;
+  ira: number;
+  rothHsa: number;
+  investedAssets: number;
+  cashLikeAssets: number;
+}
+
 export function getHoldingBalances(holdings: Holding[]): HoldingBalances {
   let taxable = 0;
   let taxableBasis = 0;
@@ -73,5 +83,21 @@ export function calculatePlannerFundingSource(
     otherAssetsAdjustment,
     liabilitiesAdjustment: normalizedLiabilitiesAdjustment,
     startingNetWorth: holdingsNetWorth + otherAssetsAdjustment - normalizedLiabilitiesAdjustment,
+  };
+}
+
+export function getPlannerPortfolioContext(holdings: Holding[]): PlannerPortfolioContext {
+  const balances = getHoldingBalances(holdings);
+  const rothHsa = balances.roth + balances.hsa;
+  const totalNetWorth = balances.taxable + balances.ira + rothHsa;
+  const investedAssets = balances.taxableInvested + balances.ira + rothHsa;
+  return {
+    totalNetWorth,
+    taxableInvested: balances.taxableInvested,
+    taxableCash: balances.taxableCash,
+    ira: balances.ira,
+    rothHsa,
+    investedAssets,
+    cashLikeAssets: balances.taxableCash,
   };
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,7 +56,7 @@ import {
   estimateAccountYieldFromBalances,
   rebalanceInvestedAccounts,
 } from './calc/rebalance';
-import { calculatePlannerFundingSource, getHoldingBalances } from './calc/portfolio-balance';
+import { calculatePlannerFundingSource, getHoldingBalances, getPlannerPortfolioContext } from './calc/portfolio-balance';
 import {
   buildDealchartsQueries,
   emptySymbolLookupResult,
@@ -305,6 +305,11 @@ const APP_HTML = `
               <h3 class="planner-subheading">Milestones</h3>
               <ul class="planner-milestone-list" id="plannerMilestoneList"></ul>
             </div>
+          </div>
+
+          <div class="planner-chart-container" style="margin-top:1.25rem;margin-bottom:0;">
+            <h3>Starting Portfolio Mix</h3>
+            <div id="plannerPortfolioContext"></div>
           </div>
         </div>
 
@@ -1557,8 +1562,9 @@ function deletePlanningScenario(id: string): void {
 function renderPlanner(forceChart = false, syncRetirementAge = true): void {
   updatePlannerFundingSourceControls();
   const result = getPlannerResult();
+  const portfolioContext = getPlannerPortfolioContext(holdings);
   if (syncRetirementAge) syncRetirementAgeDefault();
-  renderPlannerPage(result, forceChart || $('pagePlanner').classList.contains('active'));
+  renderPlannerPage(result, forceChart || $('pagePlanner').classList.contains('active'), portfolioContext);
   renderScenarioManager();
 }
 

--- a/src/render/planner.ts
+++ b/src/render/planner.ts
@@ -1,6 +1,7 @@
 import { $ } from '../utils/dom';
 import { fmt, fmtK } from '../utils/format';
 import type { FirePlannerResult } from '../calc/fire';
+import type { PlannerPortfolioContext } from '../calc/portfolio-balance';
 
 function drawPlannerChart(result: FirePlannerResult): void {
   const canvas = document.getElementById('plannerProjectionChart') as HTMLCanvasElement | null;
@@ -113,7 +114,11 @@ function drawPlannerChart(result: FirePlannerResult): void {
   ctx.stroke();
 }
 
-export function renderPlannerPage(result: FirePlannerResult, shouldDrawChart: boolean): void {
+export function renderPlannerPage(
+  result: FirePlannerResult,
+  shouldDrawChart: boolean,
+  portfolioContext: PlannerPortfolioContext,
+): void {
   const statusMap = {
     on_track: { className: 'on-track' },
     close: { className: 'behind' },
@@ -187,6 +192,37 @@ export function renderPlannerPage(result: FirePlannerResult, shouldDrawChart: bo
       <span class="planner-milestone-desc">${milestone.target === 'FIRE' ? 'Retirement ready' : milestone.target === 'SS' ? 'Social Security starts' : `$${fmtK(milestone.target)} net worth`}</span>
     </li>
   `).join('');
+
+  const totalNetWorth = portfolioContext.totalNetWorth;
+  const shareOf = (amount: number) => totalNetWorth > 0 ? Math.round((amount / totalNetWorth) * 100) : 0;
+  $('plannerPortfolioContext').innerHTML = totalNetWorth > 0
+    ? `
+      <div class="planner-results-grid" style="margin-bottom:0;">
+        <div class="stat blue">
+          <div class="label">Taxable Invested</div>
+          <div class="value">$${fmtK(portfolioContext.taxableInvested)}</div>
+          <div class="sub">${shareOf(portfolioContext.taxableInvested)}% of starting portfolio</div>
+        </div>
+        <div class="stat blue">
+          <div class="label">Taxable Cash</div>
+          <div class="value">$${fmtK(portfolioContext.taxableCash)}</div>
+          <div class="sub">${shareOf(portfolioContext.taxableCash)}% cash-like assets</div>
+        </div>
+        <div class="stat blue">
+          <div class="label">Traditional IRA</div>
+          <div class="value">$${fmtK(portfolioContext.ira)}</div>
+          <div class="sub">${shareOf(portfolioContext.ira)}% tax-deferred</div>
+        </div>
+        <div class="stat blue">
+          <div class="label">Roth + HSA</div>
+          <div class="value">$${fmtK(portfolioContext.rothHsa)}</div>
+          <div class="sub">${shareOf(portfolioContext.rothHsa)}% tax-free accounts</div>
+        </div>
+      </div>
+      <div class="planner-hint" style="margin-top:0.75rem;">
+        Planner starting capital is sourced from the same account-aware holdings data used by drawdown and Roth conversion simulations.
+      </div>`
+    : '<div class="planner-hint">No holdings loaded yet. Portfolio mix will appear here once holdings are added or imported.</div>';
 
   if (shouldDrawChart) drawPlannerChart(result);
 }

--- a/tests/calc/portfolio-balance.test.ts
+++ b/tests/calc/portfolio-balance.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   calculatePlannerFundingSource,
   getHoldingBalances,
+  getPlannerPortfolioContext,
   getPortfolioNetWorth,
   getPortfolioNetWorthFromBalances,
 } from '../../src/calc/portfolio-balance';
@@ -43,5 +44,17 @@ describe('portfolio-balance helpers', () => {
     expect(funding.otherAssetsAdjustment).toBe(50000);
     expect(funding.liabilitiesAdjustment).toBe(10000);
     expect(funding.startingNetWorth).toBe(68500);
+  });
+
+  it('builds an account-aware planner portfolio context from holdings', () => {
+    const context = getPlannerPortfolioContext(holdings);
+
+    expect(context.totalNetWorth).toBe(28500);
+    expect(context.taxableInvested).toBe(15000);
+    expect(context.taxableCash).toBe(1000);
+    expect(context.ira).toBe(7200);
+    expect(context.rothHsa).toBe(5300);
+    expect(context.investedAssets).toBe(27500);
+    expect(context.cashLikeAssets).toBe(1000);
   });
 });


### PR DESCRIPTION
## Summary
- add a shared planner portfolio-context helper derived from holdings
- surface taxable invested, taxable cash, IRA, and Roth/HSA mix on the retirement-age page
- make the planner page explicitly use the same account-aware holdings inputs as drawdown and conversion

## Testing
- npm test
- npm run build

Closes #32