### PR TITLE
Add planner drawdown consistency checks

### DIFF
--- a/src/calc/drawdown.ts
+++ b/src/calc/drawdown.ts
@@ -3,6 +3,7 @@ import { RMD_TABLE } from '../constants/tax';
 export interface DrawdownParams {
   currentAge: number;
   retireAge: number;
+  endAge?: number;
   expenses: number;
   inflation: number;
   returnRate: number;
@@ -64,7 +65,7 @@ export function getRmdFactor(age: number): number {
  */
 export function simulateDrawdown(params: DrawdownParams): DrawdownSimResult {
   const {
-    currentAge, retireAge, expenses, inflation, returnRate: growth,
+    currentAge, retireAge, endAge, expenses, inflation, returnRate: growth,
     taxRate: ordTax, ltcgRate: ltcgTax, ssAnnual,
     iraBalance, rothBalance, taxableBalance, taxableCostBasis,
   } = params;
@@ -77,7 +78,7 @@ export function simulateDrawdown(params: DrawdownParams): DrawdownSimResult {
   let roth = rothBalance * Math.pow(1 + growth, yearsToRetire);
 
   const years: DrawdownYearResult[] = [];
-  const maxYears = 50;
+  const maxYears = endAge != null ? Math.max(endAge - retireAge + 1, 1) : 50;
   let age = retireAge;
 
   for (let y = 0; y < maxYears; y++) {

--- a/src/calc/planner-consistency.ts
+++ b/src/calc/planner-consistency.ts
@@ -1,0 +1,99 @@
+import type { PlannerPortfolioContext } from './portfolio-balance';
+
+export type PlannerConsistencyStatus = 'validated' | 'warning' | 'caution';
+
+export interface PlannerConsistencyInput {
+  plannerFireAge: number | null;
+  selectedRetirementAge: number;
+  plannerRetireExpenses: number;
+  plannerLongevityAge: number;
+  drawdownSpending: number;
+  drawdownLifeExp: number;
+  drawdownDepletionAge: number | null;
+  drawdownFinalBalance: number;
+  otherAssetsAdjustment: number;
+  liabilitiesAdjustment: number;
+  portfolioContext: PlannerPortfolioContext;
+}
+
+export interface PlannerConsistencyResult {
+  status: PlannerConsistencyStatus;
+  title: string;
+  summary: string;
+  drivers: string[];
+}
+
+function fmtMoney(value: number): string {
+  const rounded = Math.round(value);
+  return `${rounded < 0 ? '-$' : '$'}${Math.abs(rounded).toLocaleString('en-US')}`;
+}
+
+export function evaluatePlannerConsistency(input: PlannerConsistencyInput): PlannerConsistencyResult {
+  const drivers: string[] = [];
+  const plannerSaysReady = input.plannerFireAge !== null && input.selectedRetirementAge >= input.plannerFireAge;
+  const drawdownFunded = input.drawdownDepletionAge === null || input.drawdownDepletionAge > input.drawdownLifeExp;
+
+  if (input.drawdownSpending > input.plannerRetireExpenses * 1.05) {
+    drivers.push(`Drawdown is testing higher annual spending (${fmtMoney(input.drawdownSpending)}) than the planner retirement-expense assumption (${fmtMoney(input.plannerRetireExpenses)}).`);
+  }
+
+  if (input.drawdownLifeExp > input.plannerLongevityAge) {
+    drivers.push(`Drawdown is testing a longer horizon (through age ${input.drawdownLifeExp}) than the planner longevity assumption (age ${input.plannerLongevityAge}).`);
+  }
+
+  if (input.otherAssetsAdjustment !== 0 || input.liabilitiesAdjustment !== 0) {
+    drivers.push(`Planner starting net worth includes manual adjustments (${fmtMoney(input.otherAssetsAdjustment)} other assets, ${fmtMoney(input.liabilitiesAdjustment)} liabilities) that are not mapped into specific drawdown accounts.`);
+  }
+
+  const iraShare = input.portfolioContext.totalNetWorth > 0
+    ? input.portfolioContext.ira / input.portfolioContext.totalNetWorth
+    : 0;
+  if (iraShare >= 0.45) {
+    drivers.push(`A large traditional IRA share (${Math.round(iraShare * 100)}% of starting portfolio) means taxes and future RMDs can make drawdown results weaker than lump-sum planner math.`);
+  }
+
+  const taxableCashShare = input.portfolioContext.totalNetWorth > 0
+    ? input.portfolioContext.taxableCash / input.portfolioContext.totalNetWorth
+    : 0;
+  if (taxableCashShare <= 0.05 && input.portfolioContext.taxableInvested > 0) {
+    drivers.push('Low taxable cash means the retirement engine has to sell invested assets earlier, which can expose taxes and sequencing drag sooner.');
+  }
+
+  if (plannerSaysReady && drawdownFunded) {
+    return {
+      status: 'validated',
+      title: 'Drawdown broadly validates this retirement age',
+      summary: `The planner says this age is funded, and the drawdown check does not run out of money before age ${input.drawdownLifeExp}. Estimated ending balance: ${fmtMoney(input.drawdownFinalBalance)}.`,
+      drivers,
+    };
+  }
+
+  if (plannerSaysReady && !drawdownFunded) {
+    return {
+      status: 'warning',
+      title: 'Drawdown does not validate this retirement age',
+      summary: `The planner reaches FIRE by age ${input.plannerFireAge}, but the drawdown check runs short by age ${input.drawdownDepletionAge}. Taxes, healthcare timing, account mix, or reconciliation adjustments are likely creating the gap.`,
+      drivers,
+    };
+  }
+
+  if (!plannerSaysReady && drawdownFunded) {
+    return {
+      status: 'caution',
+      title: 'Drawdown survives, but the planner still flags this age as aggressive',
+      summary: input.plannerFireAge !== null
+        ? `The drawdown check stays funded through age ${input.drawdownLifeExp}, but the planner does not mark the portfolio as retirement-ready until age ${input.plannerFireAge}.`
+        : `The drawdown check stays funded through age ${input.drawdownLifeExp}, but the planner never reaches its FIRE threshold under the current assumptions.`,
+      drivers,
+    };
+  }
+
+  return {
+    status: 'caution',
+    title: 'Both views treat this retirement age as aggressive',
+    summary: input.plannerFireAge !== null
+      ? `The planner does not reach FIRE until age ${input.plannerFireAge}, and the drawdown check also runs short${input.drawdownDepletionAge !== null ? ` by age ${input.drawdownDepletionAge}` : ''}.`
+      : `The planner never reaches its FIRE threshold under the current assumptions, and the drawdown check also runs short${input.drawdownDepletionAge !== null ? ` by age ${input.drawdownDepletionAge}` : ''}.`,
+    drivers,
+  };
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,6 +40,7 @@ import { calcAcaSubsidy, calcAcaSubsidyForYear, estimateBenchmarkPremium, estima
 import { calcFederalIncomeTax, calcPayrollTax, calcProgressiveTax, calcTaxableSocialSecurity, getTopOfOrdinaryBracketGrossIncome } from './calc/tax';
 import { recommendRothConversion } from './calc/conversion';
 import { getIrmaaSurcharge, getMedicareAnnualCost } from './calc/medicare';
+import { evaluatePlannerConsistency } from './calc/planner-consistency';
 import { ACA_FPL_ADDITIONAL_PERSON_BASELINE, ACA_FPL_BASELINE, ACA_PLANNING_BASELINE_LABEL } from './constants/aca';
 import { IRMAA_BRACKETS, MEDICARE_PLANNING_BASELINE_LABEL } from './constants/medicare';
 import { PLANNING_GROWTH_RATES } from './constants/planning';
@@ -288,6 +289,7 @@ const APP_HTML = `
         <div class="panel">
           <h2>Retirement Age Calculator</h2>
           <div id="plannerStatusBadge"></div>
+          <div id="plannerConsistencyArea"></div>
           <div class="planner-results-grid" id="plannerResultsGrid"></div>
 
           <div class="planner-chart-container">
@@ -1559,12 +1561,56 @@ function deletePlanningScenario(id: string): void {
   renderDrawdownScenarioBanner();
 }
 
+function getPlannerConsistencyResult(plannerResult: ReturnType<typeof getPlannerResult>) {
+  const balances = getHoldingBalances(holdings);
+  const currentAge = readInt('currentAge', 30);
+  const retireAge = readRetirementAge();
+  const lifeExp = readInt('dpLifeExp', 90);
+  const spending = readFloat('dpSpending', 50000);
+  const ssIncome = readFloat('dpSSIncome', 0);
+  const inflation = readFloat('inflationRate', 3) / 100;
+  const yearsFromStart = Math.max(retireAge - currentAge, 0);
+  const withdrawalProxyIncome = Math.max(spending - ssIncome, 0);
+  const ordinaryTaxRate = calcFederalIncomeTax(withdrawalProxyIncome, 0, yearsFromStart, inflation).effectiveRate;
+  const ltcgTaxRate = calcFederalIncomeTax(0, withdrawalProxyIncome, yearsFromStart, inflation).effectiveRate;
+  const drawdown = simulateDrawdown({
+    currentAge,
+    retireAge,
+    endAge: lifeExp,
+    expenses: spending,
+    inflation,
+    returnRate: readFloat('returnRate', 7) / 100,
+    taxRate: ordinaryTaxRate,
+    ltcgRate: ltcgTaxRate,
+    ssAnnual: ssIncome,
+    iraBalance: balances.ira,
+    rothBalance: balances.roth + balances.hsa,
+    taxableBalance: balances.taxable,
+    taxableCostBasis: balances.taxableBasis,
+  });
+
+  return evaluatePlannerConsistency({
+    plannerFireAge: plannerResult.fireAge,
+    selectedRetirementAge: retireAge,
+    plannerRetireExpenses: readFloat('retireExpenses', 40000),
+    plannerLongevityAge: readInt('longevityAge', 95),
+    drawdownSpending: spending,
+    drawdownLifeExp: lifeExp,
+    drawdownDepletionAge: drawdown.depletionAge,
+    drawdownFinalBalance: drawdown.finalBalance,
+    otherAssetsAdjustment: readFloat('otherAssetsAdjustment', 0),
+    liabilitiesAdjustment: readFloat('liabilitiesAdjustment', 0),
+    portfolioContext: getPlannerPortfolioContext(holdings),
+  });
+}
+
 function renderPlanner(forceChart = false, syncRetirementAge = true): void {
   updatePlannerFundingSourceControls();
   const result = getPlannerResult();
   const portfolioContext = getPlannerPortfolioContext(holdings);
   if (syncRetirementAge) syncRetirementAgeDefault();
-  renderPlannerPage(result, forceChart || $('pagePlanner').classList.contains('active'), portfolioContext);
+  const consistency = getPlannerConsistencyResult(result);
+  renderPlannerPage(result, forceChart || $('pagePlanner').classList.contains('active'), portfolioContext, consistency);
   renderScenarioManager();
 }
 

--- a/src/render/planner.ts
+++ b/src/render/planner.ts
@@ -1,6 +1,7 @@
 import { $ } from '../utils/dom';
 import { fmt, fmtK } from '../utils/format';
 import type { FirePlannerResult } from '../calc/fire';
+import type { PlannerConsistencyResult } from '../calc/planner-consistency';
 import type { PlannerPortfolioContext } from '../calc/portfolio-balance';
 
 function drawPlannerChart(result: FirePlannerResult): void {
@@ -118,6 +119,7 @@ export function renderPlannerPage(
   result: FirePlannerResult,
   shouldDrawChart: boolean,
   portfolioContext: PlannerPortfolioContext,
+  consistency: PlannerConsistencyResult,
 ): void {
   const statusMap = {
     on_track: { className: 'on-track' },
@@ -129,8 +131,21 @@ export function renderPlannerPage(
     result.yearsToFire !== null
       ? `${result.yearsToFire} year${result.yearsToFire === 1 ? '' : 's'} away`
       : 'Not reached';
+  const consistencyTone = consistency.status === 'validated'
+    ? 'positive'
+    : consistency.status === 'warning'
+      ? 'negative'
+      : 'neutral';
 
   $('plannerStatusBadge').innerHTML = `<div class="planner-status-badge ${status.className}">${yearsAwayLabel}</div>`;
+  $('plannerConsistencyArea').innerHTML = `
+    <div class="co-optimal-callout ${consistencyTone}" style="margin-bottom:1rem;">
+      <div class="co-optimal-title">${consistency.title}</div>
+      <div class="co-optimal-sub">
+        ${consistency.summary}
+        ${consistency.drivers.length > 0 ? `<br><br><strong>Why:</strong><br>${consistency.drivers.join('<br>')}` : ''}
+      </div>
+    </div>`;
 
   $('plannerResultsGrid').innerHTML = `
     <div class="stat blue">

--- a/tests/calc/planner-consistency.test.ts
+++ b/tests/calc/planner-consistency.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { evaluatePlannerConsistency } from '../../src/calc/planner-consistency';
+import type { PlannerPortfolioContext } from '../../src/calc/portfolio-balance';
+
+const basePortfolio: PlannerPortfolioContext = {
+  totalNetWorth: 1000000,
+  taxableInvested: 250000,
+  taxableCash: 25000,
+  ira: 500000,
+  rothHsa: 225000,
+  investedAssets: 975000,
+  cashLikeAssets: 25000,
+};
+
+describe('evaluatePlannerConsistency', () => {
+  it('returns validated when planner and drawdown both support the selected age', () => {
+    const result = evaluatePlannerConsistency({
+      plannerFireAge: 55,
+      selectedRetirementAge: 56,
+      plannerRetireExpenses: 60000,
+      plannerLongevityAge: 95,
+      drawdownSpending: 60000,
+      drawdownLifeExp: 95,
+      drawdownDepletionAge: null,
+      drawdownFinalBalance: 350000,
+      otherAssetsAdjustment: 0,
+      liabilitiesAdjustment: 0,
+      portfolioContext: basePortfolio,
+    });
+
+    expect(result.status).toBe('validated');
+    expect(result.title).toContain('validates');
+  });
+
+  it('returns warning when planner says ready but drawdown depletes early', () => {
+    const result = evaluatePlannerConsistency({
+      plannerFireAge: 55,
+      selectedRetirementAge: 56,
+      plannerRetireExpenses: 60000,
+      plannerLongevityAge: 95,
+      drawdownSpending: 75000,
+      drawdownLifeExp: 97,
+      drawdownDepletionAge: 88,
+      drawdownFinalBalance: 0,
+      otherAssetsAdjustment: 100000,
+      liabilitiesAdjustment: 0,
+      portfolioContext: basePortfolio,
+    });
+
+    expect(result.status).toBe('warning');
+    expect(result.drivers.some((driver) => driver.includes('manual adjustments'))).toBe(true);
+    expect(result.drivers.some((driver) => driver.includes('higher annual spending'))).toBe(true);
+  });
+
+  it('returns caution when drawdown survives but planner does not yet mark the age as funded', () => {
+    const result = evaluatePlannerConsistency({
+      plannerFireAge: 60,
+      selectedRetirementAge: 56,
+      plannerRetireExpenses: 60000,
+      plannerLongevityAge: 95,
+      drawdownSpending: 60000,
+      drawdownLifeExp: 95,
+      drawdownDepletionAge: null,
+      drawdownFinalBalance: 100000,
+      otherAssetsAdjustment: 0,
+      liabilitiesAdjustment: 0,
+      portfolioContext: basePortfolio,
+    });
+
+    expect(result.status).toBe('caution');
+    expect(result.summary).toContain('retirement-ready until age 60');
+  });
+});


### PR DESCRIPTION
## Summary
- add a planner consistency callout that compares the retirement-age result to a drawdown viability check
- explain likely mismatch drivers such as spending horizon changes, manual adjustments, taxes, and IRA-heavy account mix
- extend the drawdown simulator with an explicit end age for consistency validation

## Testing
- npm test
- npm run build

Closes #31